### PR TITLE
Add stats-dump and stats-restore files

### DIFF
--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -57,6 +57,9 @@ const (
 	// pod archive
 	PodOptionsFile = "pod.options"
 	PodDumpFile    = "pod.dump"
+
+	StatsDump    = "stats-dump"
+	StatsRestore = "stats-restore"
 )
 
 type CheckpointType int


### PR DESCRIPTION
To be able to include stats-dump and stats-restore from CRIU in the checkpoint archive in Podman, this commit adds a definition for those two files.