### PR TITLE
metadata: Add DevShmCheckpointTar

### DIFF
--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -52,6 +52,7 @@ const (
 	SpecDumpFile        = "spec.dump"
 	NetworkStatusFile   = "network.status"
 	CheckpointDirectory = "checkpoint"
+	DevShmCheckpointTar = "devshm-checkpoint.tar"
 	RootFsDiffTar       = "rootfs-diff.tar"
 	DeletedFilesFile    = "deleted.files"
 	// pod archive


### PR DESCRIPTION
When Podman is running a container in private IPC mode (default), it creates a bind mount for `/dev/shm` that is attached to a tmpfs folder on the host file system. However, checkpointing a container has the side-effect of stopping that container and unmount the tmpfs used for `/dev/shm`. As a result, after checkpoint all files stored in the container's `/dev/shm` would be lost and the container restore might fail.

To address this problem, this commit defines a metadata tar file that could be used to store the content of `/dev/shm`, include it in the container checkpoint, and restore it.