### PR TITLE
Add alias and '--all' option to checkpointctl show

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ $ checkpointctl show /var/lib/kubelet/checkpoints/checkpoint-counters_default-co
 ```
 
 It is also possible to display additional checkpoint related information
-with the parameter `--print-stats`:
+with the parameter `--stats`:
 
 ```console
-$ checkpointctl show /tmp/dump.tar --print-stats
+$ checkpointctl show /tmp/dump.tar --stats
 
 +-----------------+------------------------------------------+--------------+---------+----------------------+--------+------------+-------------------+
 |    CONTAINER    |                  IMAGE                   |      ID      | RUNTIME |       CREATED        | ENGINE | CHKPT SIZE | ROOT FS DIFF SIZE |
 +-----------------+------------------------------------------+--------------+---------+----------------------+--------+------------+-------------------+
 | magical_murdock | quay.io/adrianreber/wildfly-hello:latest | f11d11844af0 | crun    | 2023-02-28T09:43:52Z | Podman | 338.2 MiB  | 177.0 KiB         |
 +-----------------+------------------------------------------+--------------+---------+----------------------+--------+------------+-------------------+
+
 CRIU dump statistics
 +---------------+-------------+--------------+---------------+---------------+---------------+
 | FREEZING TIME | FROZEN TIME | MEMDUMP TIME | MEMWRITE TIME | PAGES SCANNED | PAGES WRITTEN |

--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -27,16 +27,20 @@ func main() {
 		SilenceUsage: true,
 	}
 
-	showCommand := setupShow()
+	showCommand, err := setupShow()
+	if err != nil {
+		os.Exit(1)
+	}
+	
 	rootCommand.AddCommand(showCommand)
 	rootCommand.Version = version
 
-	if err := rootCommand.Execute(); err != nil {
+	if err = rootCommand.Execute(); err != nil {
 		os.Exit(1)
 	}
 }
 
-func setupShow() *cobra.Command {
+func setupShow() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show information about available checkpoints",
@@ -47,6 +51,12 @@ func setupShow() *cobra.Command {
 	flags.BoolVar(
 		&printStats,
 		"print-stats",
+		false,
+		"Print checkpointing statistics if available",
+	)
+	flags.BoolVar(
+		&printStats,
+		"stats",
 		false,
 		"Print checkpointing statistics if available",
 	)
@@ -63,7 +73,8 @@ func setupShow() *cobra.Command {
 		"Display mounts with full paths",
 	)
 
-	return cmd
+	err := flags.MarkHidden("print-stats")
+	return cmd, err
 }
 
 func show(cmd *cobra.Command, args []string) error {

--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/containers/storage/pkg/archive"
@@ -28,20 +29,16 @@ func main() {
 		SilenceUsage: true,
 	}
 
-	showCommand, err := setupShow()
-	if err != nil {
-		os.Exit(1)
-	}
-	
+	showCommand := setupShow()
 	rootCommand.AddCommand(showCommand)
 	rootCommand.Version = version
 
-	if err = rootCommand.Execute(); err != nil {
+	if err := rootCommand.Execute(); err != nil {
 		os.Exit(1)
 	}
 }
 
-func setupShow() (*cobra.Command, error) {
+func setupShow() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show information about available checkpoints",
@@ -81,7 +78,10 @@ func setupShow() (*cobra.Command, error) {
 	)
 
 	err := flags.MarkHidden("print-stats")
-	return cmd, err
+	if err != nil {
+		log.Fatal(err)
+	}
+	return cmd
 }
 
 func show(cmd *cobra.Command, args []string) error {
@@ -90,7 +90,7 @@ func show(cmd *cobra.Command, args []string) error {
 		showMounts = true
 	}
 	if fullPaths && !showMounts {
-		return fmt.Errorf("Cannot use --full-paths without --mounts/-all option")
+		return fmt.Errorf("Cannot use --full-paths without --mounts/--all option")
 	}
 
 	input := args[0]

--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -16,6 +16,7 @@ var (
 	printStats bool
 	showMounts bool
 	fullPaths  bool
+	showAll    bool
 )
 
 func main() {
@@ -72,14 +73,24 @@ func setupShow() (*cobra.Command, error) {
 		false,
 		"Display mounts with full paths",
 	)
+	flags.BoolVar(
+		&showAll,
+		"all",
+		false,
+		"Display all additional information about the checkpoints",
+	)
 
 	err := flags.MarkHidden("print-stats")
 	return cmd, err
 }
 
 func show(cmd *cobra.Command, args []string) error {
+	if showAll {
+		printStats = true
+		showMounts = true
+	}
 	if fullPaths && !showMounts {
-		return fmt.Errorf("Cannot use --full-paths without --mounts option")
+		return fmt.Errorf("Cannot use --full-paths without --mounts/-all option")
 	}
 
 	input := args[0]

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -160,15 +160,31 @@ function teardown() {
 	[[ ${lines[10]} == *"/proc"* ]]
 }
 
+@test "Run checkpointctl show with tar file and --all and valid spec.dump and valid stats-dump" {
+	cp test/config.dump "$TEST_TMP_DIR1"
+	cp test/spec.dump "$TEST_TMP_DIR1"
+	cp test/stats-dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar --all
+	[ "$status" -eq 0 ]
+	[[ ${lines[6]} == *"Overview of Mounts"* ]]
+	[[ ${lines[8]} == *"DESTINATION"* ]]
+	[[ ${lines[10]} == *"/proc"* ]]
+	[[ ${lines[11]} == *"/etc/hostname"* ]]
+	[[ ${lines[13]} == *"CRIU dump statistics"* ]]
+	[[ ${lines[15]} == *"MEMWRITE TIME"* ]]
+	[[ ${lines[17]} == *"446571 us"* ]]
+}
 
-@test "Run checkpointctl show with tar file and missing --mounts and --full-paths" {
+@test "Run checkpointctl show with tar file and missing --mounts/--all and --full-paths" {
 	cp test/config.dump "$TEST_TMP_DIR1"
 	cp test/spec.dump "$TEST_TMP_DIR1"
 	mkdir "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl show "$TEST_TMP_DIR2"/test.tar --full-paths
 	[ "$status" -eq 1 ]
-	[[ ${lines[0]} == *"Error: Cannot use --full-paths without --mounts/-all option"* ]]
+	[[ ${lines[0]} == *"Error: Cannot use --full-paths without --mounts/--all option"* ]]
 }
 
 @test "Run checkpointctl show with tar file with valid config.dump and valid spec.dump (CRI-O) and no checkpoint directory" {

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -102,34 +102,34 @@ function teardown() {
 	[[ ${lines[4]} == *"containerd"* ]]
 }
 
-@test "Run checkpointctl show with tar file and --print-stats and missing stats-dump" {
+@test "Run checkpointctl show with tar file and --stats and missing stats-dump" {
 	cp test/config.dump "$TEST_TMP_DIR1"
 	cp test/spec.dump "$TEST_TMP_DIR1"
 	mkdir "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
-	checkpointctl show "$TEST_TMP_DIR2"/test.tar --print-stats
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar --stats
 	[ "$status" -eq 1 ]
 	[[ ${lines[6]} == *"unable to display checkpointing statistics"* ]]
 }
 
-@test "Run checkpointctl show with tar file and --print-stats and invalid stats-dump" {
+@test "Run checkpointctl show with tar file and --stats and invalid stats-dump" {
 	cp test/config.dump "$TEST_TMP_DIR1"
 	cp test/spec.dump "$TEST_TMP_DIR1"
 	cp test/spec.dump "$TEST_TMP_DIR1"/stats-dump
 	mkdir "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
-	checkpointctl show "$TEST_TMP_DIR2"/test.tar --print-stats
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar --stats
 	[ "$status" -eq 1 ]
 	[[ ${lines[6]} == *"Unknown magic"* ]]
 }
 
-@test "Run checkpointctl show with tar file and --print-stats and valid stats-dump" {
+@test "Run checkpointctl show with tar file and --stats and valid stats-dump" {
 	cp test/config.dump "$TEST_TMP_DIR1"
 	cp test/spec.dump "$TEST_TMP_DIR1"
 	cp test/stats-dump "$TEST_TMP_DIR1"
 	mkdir "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
-	checkpointctl show "$TEST_TMP_DIR2"/test.tar --print-stats
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar --stats
 	[ "$status" -eq 0 ]
 	[[ ${lines[6]} == *"CRIU dump statistics"* ]]
 	[[ ${lines[8]} == *"MEMWRITE TIME"* ]]

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -168,7 +168,7 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl show "$TEST_TMP_DIR2"/test.tar --full-paths
 	[ "$status" -eq 1 ]
-	[[ ${lines[0]} == *"Error: Cannot use --full-paths without --mounts option"* ]]
+	[[ ${lines[0]} == *"Error: Cannot use --full-paths without --mounts/-all option"* ]]
 }
 
 @test "Run checkpointctl show with tar file with valid config.dump and valid spec.dump (CRI-O) and no checkpoint directory" {


### PR DESCRIPTION
This pull request adds an alias for the `--print-stats` option, to be changed to `--stats` to maintain consistency among option names of `checkpointctl show`.

Also, an `-all` option is added to display all additional information about the available checkpoints, which would extend the *out* to look like: 

```
checkpointctl show checkpoint.tar.gz --all

Displaying container checkpoint data from /tmp/checkpointctl1209302006

+----------------+--------------------------------+--------------+---------+---------------------------+--------+------------+-------------------+
|   CONTAINER    |             IMAGE              |      ID      | RUNTIME |          CREATED          | ENGINE | CHKPT SIZE | ROOT FS DIFF SIZE |
+----------------+--------------------------------+--------------+---------+---------------------------+--------+------------+-------------------+
| cool_heyrovsky | docker.io/library/httpd:latest | 7fb253cbd7c0 | crun    | 2023-04-14T04:46:00+05:30 | Podman | 5.3 MiB    | 2.0 KiB           |
+----------------+--------------------------------+--------------+---------+---------------------------+--------+------------+-------------------+

Overview of Mounts
+--------------------+--------+---------------------------+
|    DESTINATION     |  TYPE  |          SOURCE           |
+--------------------+--------+---------------------------+
| /proc              | proc   | proc                      |
| /dev               | tmpfs  | tmpfs                     |
| /sys               | sysfs  | sysfs                     |
| /dev/pts           | devpts | devpts                    |
| /dev/mqueue        | mqueue | mqueue                    |
| /etc/hostname      | bind   | ../userdata/hostname      |
| /run/.containerenv | bind   | ../userdata/.containerenv |
| /etc/resolv.conf   | bind   | ../userdata/resolv.conf   |
| /etc/hosts         | bind   | ../userdata/hosts         |
| /dev/shm           | bind   | ../userdata/shm           |
| /sys/fs/cgroup     | cgroup | cgroup                    |
+--------------------+--------+---------------------------+

CRIU dump statistics
+---------------+-------------+--------------+---------------+---------------+---------------+
| FREEZING TIME | FROZEN TIME | MEMDUMP TIME | MEMWRITE TIME | PAGES SCANNED | PAGES WRITTEN |
+---------------+-------------+--------------+---------------+---------------+---------------+
| 5333 us       | 200318 us   | 111941 us    | 75612 us      |        239777 |         45512 |
+---------------+-------------+--------------+---------------+---------------+---------------+
```