### PR TITLE
Optimize archive unpacking

### DIFF
--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -44,11 +44,12 @@ function teardown() {
 	touch "$TEST_TMP_DIR1"/empty.tar
 	checkpointctl show "$TEST_TMP_DIR1"/empty.tar
 	[ "$status" -eq 1 ]
-	[[ ${lines[0]} == *"config.dump: no such file or directory"* ]]
+	[[ ${lines[0]} == *"checkpoint directory is missing in the archive file"* ]]
 }
 
 @test "Run checkpointctl show with tar file with empty config.dump" {
 	touch "$TEST_TMP_DIR1"/config.dump
+	mkdir "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl show "$TEST_TMP_DIR2"/test.tar
 	[ "$status" -eq 1 ]
@@ -57,6 +58,7 @@ function teardown() {
 
 @test "Run checkpointctl show with tar file with valid config.dump and no spec.dump" {
 	cp test/config.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl show "$TEST_TMP_DIR2"/test.tar
 	[ "$status" -eq 1 ]
@@ -65,6 +67,7 @@ function teardown() {
 
 @test "Run checkpointctl show with tar file with valid config.dump and empty spec.dump" {
 	cp test/config.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
 	touch "$TEST_TMP_DIR1"/spec.dump
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl show "$TEST_TMP_DIR2"/test.tar
@@ -78,7 +81,7 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl show "$TEST_TMP_DIR2"/test.tar
 	[ "$status" -eq 1 ]
-	[[ ${lines[1]} == *"checkpoint: no such file or directory" ]]
+	[[ ${lines[0]} == *"Error: checkpoint directory is missing in the archive file"* ]]
 }
 
 @test "Run checkpointctl show with tar file with valid config.dump and valid spec.dump and checkpoint directory" {
@@ -193,7 +196,7 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl show "$TEST_TMP_DIR2"/test.tar
 	[ "$status" -eq 1 ]
-	[[ ${lines[1]} == *"checkpoint: no such file or directory"* ]]
+	[[ ${lines[0]} == *"Error: checkpoint directory is missing in the archive file"* ]]
 }
 
 @test "Run checkpointctl show with tar file with valid config.dump and valid spec.dump (CRI-O) and checkpoint directory" {
@@ -205,3 +208,48 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ ${lines[4]} == *"CRI-O"* ]]
 }
+
+@test "Run checkpointctl show with tar file compressed" {
+	cp test/config.dump "$TEST_TMP_DIR1"
+	cp test/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar czf "$TEST_TMP_DIR2"/test.tar.gz . )
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar.gz
+	[ "$status" -eq 0 ]
+	[[ ${lines[4]} == *"Podman"* ]]
+}
+
+@test "Run checkpointctl show with tar file corrupted" {
+	cp test/config.dump "$TEST_TMP_DIR1"
+	cp test/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	dd if=/dev/urandom of="$TEST_TMP_DIR2"/test.tar bs=1 count=10 seek=2 conv=notrunc
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"Error: archive/tar: invalid tar header"* ]]
+}
+
+@test "Run checkpointctl show with tar file compressed and corrupted" {
+	cp test/config.dump "$TEST_TMP_DIR1"
+	cp test/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar czf "$TEST_TMP_DIR2"/test.tar.gz . )
+	dd if=/dev/urandom of="$TEST_TMP_DIR2"/test.tar.gz bs=1 count=10 seek=2 conv=notrunc
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar.gz
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"Error: unexpected EOF"* ]]
+}
+
+@test "Run checkpointctl show with tar file and rootfs-diff tar file" {
+	cp test/config.dump "$TEST_TMP_DIR1"
+	cp test/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	echo 1 > "$TEST_TMP_DIR1"/test.pid
+	tar -cf "$TEST_TMP_DIR1"/rootfs-diff.tar -C "$TEST_TMP_DIR1" test.pid
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl show "$TEST_TMP_DIR2"/test.tar
+	[ "$status" -eq 0 ]
+	[[ ${lines[2]} == *"ROOT FS DIFF SIZE"* ]]
+}
+


### PR DESCRIPTION
This PR propose an approach to optimize checkpoint archive unpacking. 

Two new functions are introduced:
- untarFiles` to extract specific files from the archive. 
- `getCheckpointAndDiffSizes`  as  replacement for `getCheckpointSize` function. This function read the sizes of the checkpoint directory and rootfs-diff.tar file from the archive without unpacking the entire archive.

Two failing test cases checking the presence of the `checkpoint` directory. Is it OK to remove those ?

cc: @adrianreber, @rst0git 

Fixes: #51 