### PR TITLE
ci: add job to check increase in binary size

### DIFF
--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -1,0 +1,22 @@
+name: Check binary size
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+
+jobs:
+  check_size:
+    runs-on: ubuntu-latest
+    # Check if pull request does not have label "bloat-ok".
+    if: "!contains(github.event.pull_request.labels.*.name, 'bloat-ok')"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        # Use HEAD from the PR instead of the merge commit
+        ref: ${{ github.event.pull_request.head.sha }}
+        # Needed to rebase against the base branch
+        fetch-depth: 0
+    - name: Configure base branch without switching current branch
+      run: git fetch origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}
+    - name: Compare binary size change across each commit
+      run: git rebase ${GITHUB_BASE_REF}^ -x test/check-size.sh

--- a/test/check-size.sh
+++ b/test/check-size.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# A shell script to check if the binary size
+# has increased beyond a certain threshold
+# across commits. Meant to be used in CI with
+# git rebase <base branch>^ -x check-size.sh
+
+# Fail fast on errors
+set -e
+
+BIN_NAME=checkpointctl
+PREV_SIZE_FILE=prev_size
+# Maximum allowable size difference, in bytes
+MAX_DIFF=51200
+
+# Build the checkpointctl binary. If the commit is not self-contained,
+# the build will fail, in which case there is no point checking for a
+# change in the size of the binary.
+make
+# Store the binary size
+BIN_SIZE=$(stat -c%s "$BIN_NAME")
+
+if [[ -f "$PREV_SIZE_FILE" ]]; then
+	# Read the previous size from the file
+	PREV_SIZE=$(cat "$PREV_SIZE_FILE")
+	# Calculate the difference between current and previous size
+	DIFF=$((BIN_SIZE - PREV_SIZE))
+	if [[ $DIFF -gt $MAX_DIFF ]]; then
+		echo "FAIL: size difference of \"$DIFF\" B exceeds limit \"$MAX_DIFF\" B"
+		exit 1
+	else
+		echo "PASS: size difference of \"$DIFF\" B within limit \"$MAX_DIFF\" B"
+	fi
+else
+	# This means this is the first run of the script.
+	# The original file size will be stored, and used
+	# to compare against subsequent values ahead.
+	echo "No previous size present, storing current size"
+	echo "$BIN_SIZE" > "$PREV_SIZE_FILE"
+fi


### PR DESCRIPTION
This job checks the difference in binary size across commits in a PR, and fails if the difference is more than a set maximum limit. This allows us to detect early on if there is any possible bloating in the binary due to poorly structured dependencies. The job can be overridden by adding a `bloat-ok` label to the PR.