### PR TITLE
refactor: move table rendering into own funcs

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -12,12 +12,12 @@ import (
 )
 
 var (
-	name       string
-	version    string
-	printStats bool
-	showMounts bool
-	fullPaths  bool
-	showAll    bool
+	name      string
+	version   string
+	stats     bool
+	mounts    bool
+	fullPaths bool
+	showAll   bool
 )
 
 func main() {
@@ -47,19 +47,19 @@ func setupShow() *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(
-		&printStats,
+		&stats,
 		"print-stats",
 		false,
 		"Print checkpointing statistics if available",
 	)
 	flags.BoolVar(
-		&printStats,
+		&stats,
 		"stats",
 		false,
 		"Print checkpointing statistics if available",
 	)
 	flags.BoolVar(
-		&showMounts,
+		&mounts,
 		"mounts",
 		false,
 		"Print overview about mounts used in the checkpoints",
@@ -86,10 +86,10 @@ func setupShow() *cobra.Command {
 
 func show(cmd *cobra.Command, args []string) error {
 	if showAll {
-		printStats = true
-		showMounts = true
+		stats = true
+		mounts = true
 	}
-	if fullPaths && !showMounts {
+	if fullPaths && !mounts {
 		return fmt.Errorf("Cannot use --full-paths without --mounts/--all option")
 	}
 

--- a/container.go
+++ b/container.go
@@ -103,11 +103,11 @@ func showContainerCheckpoint(checkpointDirectory, input string) error {
 
 	renderCheckpoint(ci, containerConfig, archiveSizes)
 
-	if showMounts {
+	if mounts {
 		renderMounts(specDump)
 	}
 
-	if printStats {
+	if stats {
 		cpDir, err := os.Open(checkpointDirectory)
 		if err != nil {
 			return err


### PR DESCRIPTION
The logic for rendering tables with the checkpoint data was all present
in a single function `showContainerCheckpoint()`. This has now been
refactored to provide each table its own function that can be called to
render it. This increases code maintainability going forward as more and
more tables are added to the `checkpointctl show` command.