### PR TITLE
fix(ci): set git credentials for rebase

### DIFF
--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        # Use HEAD from the PR instead of the merge commit
-        ref: ${{ github.event.pull_request.head.sha }}
         # Needed to rebase against the base branch
         fetch-depth: 0
     - name: Configure git user details
@@ -23,4 +21,4 @@ jobs:
     - name: Configure base branch without switching current branch
       run: git fetch origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}
     - name: Compare binary size change across each commit
-      run: git rebase ${GITHUB_BASE_REF}^ -x test/check-size.sh
+      run: git rebase -v ${GITHUB_BASE_REF}^ -x test/check-size.sh

--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -16,6 +16,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         # Needed to rebase against the base branch
         fetch-depth: 0
+    - name: Configure git user details
+      run: |
+        git config --global user.email "bloatchecker@example.com"
+        git config --global user.name "Bloat Checker"
     - name: Configure base branch without switching current branch
       run: git fetch origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}
     - name: Compare binary size change across each commit

--- a/test/check-size.sh
+++ b/test/check-size.sh
@@ -19,6 +19,8 @@ MAX_DIFF=51200
 make
 # Store the binary size
 BIN_SIZE=$(stat -c%s "$BIN_NAME")
+# Print the size along with the commit hash
+echo "BINARY SIZE ($(git rev-parse --short HEAD)): $BIN_SIZE"
 
 if [[ -f "$PREV_SIZE_FILE" ]]; then
 	# Read the previous size from the file
@@ -26,10 +28,10 @@ if [[ -f "$PREV_SIZE_FILE" ]]; then
 	# Calculate the difference between current and previous size
 	DIFF=$((BIN_SIZE - PREV_SIZE))
 	if [[ $DIFF -gt $MAX_DIFF ]]; then
-		echo "FAIL: size difference of \"$DIFF\" B exceeds limit \"$MAX_DIFF\" B"
+		echo "FAIL: size difference of $DIFF B exceeds limit $MAX_DIFF B"
 		exit 1
 	else
-		echo "PASS: size difference of \"$DIFF\" B within limit \"$MAX_DIFF\" B"
+		echo "PASS: size difference of $DIFF B within limit $MAX_DIFF B"
 	fi
 else
 	# This means this is the first run of the script.
@@ -38,3 +40,7 @@ else
 	echo "No previous size present, storing current size"
 	echo "$BIN_SIZE" > "$PREV_SIZE_FILE"
 fi
+
+# Remove the binary to ensure it is
+# built again with the next commit
+rm -f $BIN_NAME


### PR DESCRIPTION
The workflow fails during rebase since git cannot find any details of a user to create the commits. This adds a dummy user to fix this.