### PR TITLE
test/check-size: show error if make fails

### DIFF
--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -14,6 +14,8 @@ jobs:
       with:
         # Needed to rebase against the base branch
         fetch-depth: 0
+        # Checkout pull request HEAD commit instead of merge commit
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Configure git user details
       run: |
         git config --global user.email "checkpoint-restore@users.noreply.github.com"

--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -16,8 +16,8 @@ jobs:
         fetch-depth: 0
     - name: Configure git user details
       run: |
-        git config --global user.email "bloatchecker@example.com"
-        git config --global user.name "Bloat Checker"
+        git config --global user.email "checkpoint-restore@users.noreply.github.com"
+        git config --global user.name "checkpoint-restore"
     - name: Configure base branch without switching current branch
       run: git fetch origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}
     - name: Compare binary size change across each commit

--- a/test/check-size.sh
+++ b/test/check-size.sh
@@ -5,9 +5,6 @@
 # across commits. Meant to be used in CI with
 # git rebase <base branch>^ -x check-size.sh
 
-# Fail fast on errors
-set -e
-
 BIN_NAME=checkpointctl
 PREV_SIZE_FILE=prev_size
 # Maximum allowable size difference, in bytes
@@ -16,7 +13,15 @@ MAX_DIFF=51200
 # Build the checkpointctl binary. If the commit is not self-contained,
 # the build will fail, in which case there is no point checking for a
 # change in the size of the binary.
-make
+if ! make; then
+	echo "ERROR: Compilation failed at $(git rev-parse --short HEAD)"
+	echo "Make sure that the compilation is successful for each commit."
+	exit 1
+fi
+
+# Fail fast on errors
+set -e
+
 # Store the binary size
 BIN_SIZE=$(stat -c%s "$BIN_NAME")
 # Print the size along with the commit hash


### PR DESCRIPTION
This pull request adds an error message when compilation fails when running the `check-size.sh` script.