### PR TITLE
ci: use Ubuntu for tests instead of Fedora

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,14 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:latest
     steps:
       - uses: actions/checkout@v3
       - name: Install tools
-        run: sudo dnf -y install ShellCheck bats golang
+        run: |
+          sudo apt-get install -qqy shellcheck
+          # Install bats from the NPM registry as the version
+          # in the Ubuntu package repository is outdated
+          npm install -g bats
       - name: Run make shellcheck
         run: make shellcheck
       - name: Run make all


### PR DESCRIPTION
Previously, the Fedora container image was being used to test checkpointctl since the Ubuntu image had an outdated version of bats. This does not affect the tests themselves, as the coverage workflow continues to use `ubuntu-latest` without issues. This change will eliminate the need for having a privileged container to run criu while generating image files for tests.