### PR TITLE
Build static checkpointctl binary for improved portability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,23 @@ jobs:
         name: event-file
         retention-days: 1
         path: ${{ github.event_path }}
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Build release binary
+      run: make release
+
+    - name: Check static binary
+      run: |
+        file_output=$(file checkpointctl)
+        if [[ "$file_output" =~ .*statically\ linked.* ]]; then
+          echo "Binary is static"
+          exit 0
+        else
+          echo "Binary is not static"
+          exit 1
+        fi

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,15 @@ help:
 	@echo "Usage: make <target>"
 	@echo " * clean - remove artifacts"
 	@echo " * lint - verify the source code (shellcheck/golangci-lint)"
-	@echo " * golang-lint - run golang-lint"
-	@echo " * shellcheck - run shellecheck"
-	@echo " * vendor - update go.mod, go.sum and vendor directory"
+	@echo " * golang-lint - run golangci-lint"
+	@echo " * shellcheck - run shellcheck"
+	@echo " * vendor - update go.mod, go.sum, and vendor directory"
 	@echo " * test - run tests"
 	@echo " * test-junit - run tests and create junit output"
+	@echo " * coverage - generate test coverage report"
+	@echo " * codecov - upload coverage report to codecov.io"
+	@echo " * install - install the binary to $(BINDIR)"
+	@echo " * uninstall - remove the installed binary from $(BINDIR)"
 	@echo " * help - show help"
 
 .PHONY: clean install uninstall lint golang-lint shellcheck vendor test help check-go-version test-junit

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ $(NAME).coverage: check-go-version $(GO_SRC)
 		-buildmode=pie -o $@ \
 		-ldflags "-X main.name=$(NAME) -X main.version=${VERSION}"
 
+release:
+	CGO_ENABLED=0 $(GO_BUILD) -o $(NAME) -ldflags "-X main.name=$(NAME) -X main.version=${VERSION}"
 
 install: $(NAME)
 	@echo "  INSTALL " $<
@@ -103,6 +105,7 @@ help:
 	@echo " * codecov - upload coverage report to codecov.io"
 	@echo " * install - install the binary to $(BINDIR)"
 	@echo " * uninstall - remove the installed binary from $(BINDIR)"
+	@echo " * release - build a static binary"
 	@echo " * help - show help"
 
-.PHONY: clean install uninstall lint golang-lint shellcheck vendor test help check-go-version test-junit
+.PHONY: clean install uninstall release lint golang-lint shellcheck vendor test help check-go-version test-junit

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ check-go-version:
 
 
 $(NAME): $(GO_SRC)
-	$(GO_BUILD) -buildmode=pie -o $@ -ldflags "-X main.name=$(NAME) -X main.version=${VERSION}"
+	$(GO_BUILD) -o $@ -ldflags "-X main.name=$(NAME) -X main.version=${VERSION}"
 
 $(NAME).coverage: check-go-version $(GO_SRC)
 	$(GO) build \
 		-cover \
-		-buildmode=pie -o $@ \
+		-o $@ \
 		-ldflags "-X main.name=$(NAME) -X main.version=${VERSION}"
 
 release:


### PR DESCRIPTION
This pull request modifies the Makefile to build a static `checkpointctl` binary and eliminate dependency on dynamic libraries. This change ensures that the resulting binary can be effortlessly distributed and executed across various systems and linux distributions. For example, a binary built on a Fedora system will seamlessly run on Ubuntu and vice versa.