### PR TITLE
show: enable shorthand options

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -52,27 +52,31 @@ func setupShow() *cobra.Command {
 		false,
 		"Print checkpointing statistics if available",
 	)
-	flags.BoolVar(
+	flags.BoolVarP(
 		&stats,
 		"stats",
+		"s",
 		false,
 		"Print checkpointing statistics if available",
 	)
-	flags.BoolVar(
+	flags.BoolVarP(
 		&mounts,
 		"mounts",
+		"m",
 		false,
 		"Print overview about mounts used in the checkpoints",
 	)
-	flags.BoolVar(
+	flags.BoolVarP(
 		&fullPaths,
 		"full-paths",
+		"F",
 		false,
 		"Display mounts with full paths",
 	)
-	flags.BoolVar(
+	flags.BoolVarP(
 		&showAll,
 		"all",
+		"A",
 		false,
 		"Display all additional information about the checkpoints",
 	)


### PR DESCRIPTION
This patch enables the following shorthand options:

```
Usage:
  checkpointctl show [flags]

Flags:
  -A, --all          Display all additional information about the checkpoints
  -F, --full-paths   Display mounts with full paths
  -h, --help         help for show
  -m, --mounts       Print overview about mounts used in the checkpoints
  -s, --stats        Print checkpointing statistics if available
```