### PR TITLE
show: add support for listing multiple checkpoints

### DIFF
--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -269,3 +269,24 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ ${lines[8]} == *"piggie"* ]]
 }
+
+@test "Run checkpointctl show with multiple tar files" {
+	cp data/config.dump "$TEST_TMP_DIR1"
+	cp data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test1.tar .  && tar cf "$TEST_TMP_DIR2"/test2.tar . )
+	checkpointctl show "$TEST_TMP_DIR2"/*.tar
+	[ "$status" -eq 0 ]
+	[[ ${lines[3]} == *"Podman"* ]]
+	[[ ${lines[5]} == *"Podman"* ]]
+}
+
+@test "Run checkpointctl show with multiple tar files with additional flags" {
+	cp data/config.dump "$TEST_TMP_DIR1"
+	cp data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test1.tar .  && tar cf "$TEST_TMP_DIR2"/test2.tar . )
+	checkpointctl show "$TEST_TMP_DIR2"/*.tar --all
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"displaying multiple checkpoints with additional flags is not supported"* ]]
+}


### PR DESCRIPTION
This commit enhances the functionality of the "show" command by enabling it to list multiple checkpoint archives.

Examples:
```bash
$ls checkpoints/
nginx-checkpoint.tar.gz  ubuntu_multiuser.tar.gz

$checkpointctl nginx-checkpoint.tar.gz  ubuntu_multiuser.tar.gz
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+
|   CONTAINER    |              IMAGE              |      ID      | RUNTIME |          CREATED          | ENGINE | IP | MAC | CHKPT SIZE | ROOT FS DIFF SIZE |
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+
| awesome_booth  | docker.io/library/ubuntu:latest | 695b77deb382 | crun    | 2023-03-08T08:45:33+03:00 | Podman |    |     | 2.8 MiB    | 309.0 KiB         |
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+
| gallant_austin | docker.io/library/nginx:latest  | 5e61a1e0a308 | crun    | 2023-03-01T15:11:55+03:00 | Podman |    |     | 16.6 MiB   | 4.5 KiB           |
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+

$checkpointctl show *.tar.gz
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+
|   CONTAINER    |              IMAGE              |      ID      | RUNTIME |          CREATED          | ENGINE | IP | MAC | CHKPT SIZE | ROOT FS DIFF SIZE |
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+
| awesome_booth  | docker.io/library/ubuntu:latest | 695b77deb382 | crun    | 2023-03-08T08:45:33+03:00 | Podman |    |     | 2.8 MiB    | 309.0 KiB         |
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+
| gallant_austin | docker.io/library/nginx:latest  | 5e61a1e0a308 | crun    | 2023-03-01T15:11:55+03:00 | Podman |    |     | 16.6 MiB   | 4.5 KiB           |
+----------------+---------------------------------+--------------+---------+---------------------------+--------+----+-----+------------+-------------------+

```

Note that when listing multiple checkpoint files, additional flags are ignored.

Fixes: #53
