### PR TITLE
fix: remove redundant nodes in process tree

### DIFF
--- a/container.go
+++ b/container.go
@@ -241,7 +241,6 @@ func renderPsTree(psTree *crit.PsTree, containerName string) {
 	processNodes = func(tree treeprint.Tree, root *crit.PsTree) {
 		node := tree.AddMetaBranch(root.PId, root.Comm)
 		for _, child := range root.Children {
-			node.AddMetaNode(child.PId, root.Comm)
 			processNodes(node, child)
 		}
 	}


### PR DESCRIPTION
The recursive logic used to process nodes in the process tree was accidentally appending child nodes twice. This has been fixed by removing the addition of the extra node at the same depth before processing the child.

Fixes #70 