### PR TITLE
fix(ci/check-size): use latest non-merge commit

### DIFF
--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -23,4 +23,5 @@ jobs:
     - name: Configure base branch without switching current branch
       run: git fetch origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}
     - name: Compare binary size change across each commit
-      run: git rebase -v ${GITHUB_BASE_REF}^ -x test/check-size.sh
+      # Use the last non-merge commit from the base branch as the baseline
+      run: git rebase -v $(git rev-list --no-merges -n 1 ${GITHUB_BASE_REF})^ -x test/check-size.sh


### PR DESCRIPTION
We were previously using the merge commit as the baseline, leading to all commits from the pull request being rebased, rather than just the latest commit.