### PR TITLE
ci: use separate job to set baseline binary size

### DIFF
--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        # Needed to rebase against the base branch
+        # Needed to rebase commits
         fetch-depth: 0
         # Checkout pull request HEAD commit instead of merge commit
         ref: ${{ github.event.pull_request.head.sha }}
@@ -20,8 +20,13 @@ jobs:
       run: |
         git config --global user.email "checkpoint-restore@users.noreply.github.com"
         git config --global user.name "checkpoint-restore"
-    - name: Configure base branch without switching current branch
-      run: git fetch origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}
+    - name: Store baseline binary size
+      run: |
+        git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+        git switch ${{ github.base_ref }}
+        # The first run of the script will store the size of the binary
+        test/check-size.sh
     - name: Compare binary size change across each commit
-      # Use the last non-merge commit from the base branch as the baseline
-      run: git rebase -v $(git rev-list --no-merges -n 1 ${GITHUB_BASE_REF})^ -x test/check-size.sh
+      run: |
+        git switch ${{ github.head_ref }}
+        git rebase ${{ github.base_ref }} -x test/check-size.sh


### PR DESCRIPTION
Sometimes our own intelligence works against us +_+ better to keep it simple