### PR TITLE
feat: filter by PID in process tree

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -17,6 +17,7 @@ var (
 	format  string
 	stats   bool
 	mounts  bool
+	pID     uint32
 	psTree  bool
 	files   bool
 	showAll bool
@@ -89,6 +90,13 @@ func setupInspect() *cobra.Command {
 		false,
 		"Display an overview of mounts used in the container checkpoint",
 	)
+	flags.Uint32VarP(
+		&pID,
+		"pid",
+		"p",
+		0,
+		"Display the process tree of a specific PID",
+	)
 	flags.BoolVar(
 		&psTree,
 		"ps-tree",
@@ -129,6 +137,11 @@ func inspect(cmd *cobra.Command, args []string) error {
 
 	if stats {
 		requiredFiles = append(requiredFiles, "stats-dump")
+	}
+
+	if pID != 0 {
+		// Enable displaying process tree if the PID filter is passed.
+		psTree = true
 	}
 
 	if files {

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -315,6 +315,31 @@ function teardown() {
 	[[ ${lines[0]} == *"failed to get file descriptors"* ]]
 }
 
+@test "Run checkpointctl inspect with tar file and --ps-tree and valid PID" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree --pid 1
+	[ "$status" -eq 0 ]
+	[[ ${lines[8]} == *"Process tree"* ]]
+	[[ ${lines[9]} == *"piggie"* ]]
+}
+
+@test "Run checkpointctl inspect with tar file and --ps-tree and invalid PID" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree --pid 99999
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"no process with PID 99999"* ]]
+}
+
 @test "Run checkpointctl inspect with tar file and --all and valid spec.dump and valid stats-dump" {
 	cp data/config.dump "$TEST_TMP_DIR1"
 	cp data/spec.dump "$TEST_TMP_DIR1"


### PR DESCRIPTION
Currently, the entire process tree is rendered in the tree view. This allows for the tree to be pruned for a specific process using the `--pid` or `-p` flag.

Fixes #86