### PR TITLE
tree: show mounts after pstree

### DIFF
--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -329,18 +329,19 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --all
 	[ "$status" -eq 0 ]
-	[[ ${lines[8]} == *"Overview of mounts"* ]]
-	[[ ${lines[9]} == *"Destination"* ]]
-	[[ ${lines[10]} == *"proc"* ]]
-	[[ ${lines[12]} == *"/etc/hostname"* ]]
-	[[ ${lines[15]} == *"CRIU dump statistics"* ]]
-	[[ ${lines[19]} == *"Memwrite time"* ]]
-	[[ ${lines[20]} =~ [1-9]+" us" ]]
-	[[ ${lines[22]} == *"Process tree"* ]]
-	[[ ${lines[23]} == *"piggie"* ]]
-	[[ ${lines[24]} == *"[REG 0]"* ]]
-	[[ ${lines[25]} == *"[cwd]"* ]]
-	[[ ${lines[26]} == *"[root]"* ]]
+	[[ ${lines[8]} == *"CRIU dump statistics"* ]]
+	[[ ${lines[12]} == *"Memwrite time"* ]]
+	[[ ${lines[13]} =~ [1-9]+" us" ]]
+	[[ ${lines[15]} == *"Process tree"* ]]
+	[[ ${lines[16]} == *"piggie"* ]]
+	[[ ${lines[17]} == *"[REG 0]"* ]]
+	[[ ${lines[18]} == *"[cwd]"* ]]
+	[[ ${lines[19]} == *"[root]"* ]]
+	[[ ${lines[20]} == *"Overview of mounts"* ]]
+	[[ ${lines[21]} == *"Destination"* ]]
+	[[ ${lines[22]} == *"proc"* ]]
+	[[ ${lines[24]} == *"/etc/hostname"* ]]
+
 }
 
 @test "Run checkpointctl inspect with tar file with valid config.dump and valid spec.dump and no checkpoint directory" {

--- a/tree.go
+++ b/tree.go
@@ -21,10 +21,6 @@ func renderTreeView(tasks []task) error {
 
 		tree := buildTree(info.containerInfo, info.configDump, info.archiveSizes)
 
-		if mounts {
-			addMountsToTree(tree, info.specDump)
-		}
-
 		if stats {
 			dumpStats, err := crit.GetDumpStats(task.outputDir)
 			if err != nil {
@@ -52,6 +48,10 @@ func renderTreeView(tasks []task) error {
 			}
 
 			addFdsToTree(tree, fds)
+		}
+
+		if mounts {
+			addMountsToTree(tree, info.specDump)
 		}
 
 		fmt.Printf("\nDisplaying container checkpoint tree view from %s\n\n", task.checkpointFilePath)


### PR DESCRIPTION
The overview of mounts used in container checkpoint is likely to be more than 30 lines. In comparison, the output for checkpoint statistics and process tree are likely to take less space. To improve readability, this patch moves the mounts overview at the end of the output of `inspect --all`.

Before:
```
looper
├── Image: docker.io/library/busybox:latest
├── ID: 03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf
├── Runtime: crun
├── Created: 2023-07-10T12:48:11+01:00
├── Engine: Podman
├── Checkpoint size: 154.5 KiB
├── Overview of mounts
│   ├── Destination: /proc
│   │   ├── Type: proc
│   │   └── Source: proc
│   ├── Destination: /dev
│   │   ├── Type: tmpfs
│   │   └── Source: tmpfs
│   ├── Destination: /sys
│   │   ├── Type: sysfs
│   │   └── Source: sysfs
│   ├── Destination: /dev/pts
│   │   ├── Type: devpts
│   │   └── Source: devpts
│   ├── Destination: /dev/mqueue
│   │   ├── Type: mqueue
│   │   └── Source: mqueue
│   ├── Destination: /etc/resolv.conf
│   │   ├── Type: bind
│   │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/resolv.conf
│   ├── Destination: /etc/hosts
│   │   ├── Type: bind
│   │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/hosts
│   ├── Destination: /dev/shm
│   │   ├── Type: bind
│   │   └── Source: /var/lib/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/shm
│   ├── Destination: /run/.containerenv
│   │   ├── Type: bind
│   │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/.containerenv
│   ├── Destination: /run/secrets
│   │   ├── Type: bind
│   │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/run/secrets
│   ├── Destination: /etc/hostname
│   │   ├── Type: bind
│   │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/hostname
│   └── Destination: /sys/fs/cgroup
│       ├── Type: cgroup
│       └── Source: cgroup
├── CRIU dump statistics
│   ├── Freezing time: 102691 us
│   ├── Frozen time: 177092 us
│   ├── Memdump time: 2582 us
│   ├── Memwrite time: 348 us
│   ├── Pages scanned: 1195 us
│   └── Pages written: 34 us
└── Process tree
    └── [1]  sh
```

After:
```
looper
├── Image: docker.io/library/busybox:latest
├── ID: 03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf
├── Runtime: crun
├── Created: 2023-07-10T12:48:11+01:00
├── Engine: Podman
├── Checkpoint size: 154.5 KiB
├── CRIU dump statistics
│   ├── Freezing time: 102691 us
│   ├── Frozen time: 177092 us
│   ├── Memdump time: 2582 us
│   ├── Memwrite time: 348 us
│   ├── Pages scanned: 1195 us
│   └── Pages written: 34 us
├── Process tree
│   └── [1]  sh
└── Overview of mounts
    ├── Destination: /proc
    │   ├── Type: proc
    │   └── Source: proc
    ├── Destination: /dev
    │   ├── Type: tmpfs
    │   └── Source: tmpfs
    ├── Destination: /sys
    │   ├── Type: sysfs
    │   └── Source: sysfs
    ├── Destination: /dev/pts
    │   ├── Type: devpts
    │   └── Source: devpts
    ├── Destination: /dev/mqueue
    │   ├── Type: mqueue
    │   └── Source: mqueue
    ├── Destination: /etc/resolv.conf
    │   ├── Type: bind
    │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/resolv.conf
    ├── Destination: /etc/hosts
    │   ├── Type: bind
    │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/hosts
    ├── Destination: /dev/shm
    │   ├── Type: bind
    │   └── Source: /var/lib/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/shm
    ├── Destination: /run/.containerenv
    │   ├── Type: bind
    │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/.containerenv
    ├── Destination: /run/secrets
    │   ├── Type: bind
    │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/run/secrets
    ├── Destination: /etc/hostname
    │   ├── Type: bind
    │   └── Source: /run/containers/storage/overlay-containers/03be7aa1b3aa16a46fff2882840afcd192d0f5c7ef79bb8d02f9a846920327cf/userdata/hostname
    └── Destination: /sys/fs/cgroup
        ├── Type: cgroup
        └── Source: cgroup
```