### PR TITLE
feat: display process tree with command line arguments

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -12,15 +12,16 @@ import (
 )
 
 var (
-	name    string
-	version string
-	format  string
-	stats   bool
-	mounts  bool
-	pID     uint32
-	psTree  bool
-	files   bool
-	showAll bool
+	name      string
+	version   string
+	format    string
+	stats     bool
+	mounts    bool
+	pID       uint32
+	psTree    bool
+	psTreeCmd bool
+	files     bool
+	showAll   bool
 )
 
 func main() {
@@ -104,6 +105,12 @@ func setupInspect() *cobra.Command {
 		"Display an overview of processes in the container checkpoint",
 	)
 	flags.BoolVar(
+		&psTreeCmd,
+		"ps-tree-cmd",
+		false,
+		"Display an overview of processes in the container checkpoint with full command line arguments",
+	)
+	flags.BoolVar(
 		&files,
 		"files",
 		false,
@@ -158,6 +165,18 @@ func inspect(cmd *cobra.Command, args []string) error {
 			filepath.Join(metadata.CheckpointDirectory, "ids-"),
 			// fdinfo-*.img
 			filepath.Join(metadata.CheckpointDirectory, "fdinfo-"),
+		)
+	}
+
+	if psTreeCmd {
+		// Enable displaying process tree when using --ps-tree-cmd.
+		psTree = true
+		requiredFiles = append(
+			requiredFiles,
+			// Unpack pagemap-*.img, pages-*.img, and mm-*.img
+			filepath.Join(metadata.CheckpointDirectory, "pagemap-"),
+			filepath.Join(metadata.CheckpointDirectory, "pages-"),
+			filepath.Join(metadata.CheckpointDirectory, "mm-"),
 		)
 	}
 

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -285,6 +285,36 @@ function teardown() {
 	[[ ${lines[0]} == *"failed to get process tree"* ]]
 }
 
+@test "Run checkpointctl inspect with tar file and --ps-tree-cmd" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/pages-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree-cmd
+	[ "$status" -eq 0 ]
+	[[ ${lines[8]} == *"Process tree"* ]]
+	[[ ${lines[9]} == *"piggie/piggie"* ]]
+}
+
+@test "Run checkpointctl inspect with tar file and --ps-tree-cmd and missing pages-*.img {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree-cmd
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"failed to process command line arguments"* ]]
+}
+
 @test "Run checkpointctl inspect with tar file and --files" {
 	cp data/config.dump \
 		data/spec.dump "$TEST_TMP_DIR1"


### PR DESCRIPTION
This PR introduces a new flag `--ps-tree-cmd` to provide an alternative view of process tree.  
Using `--ps-tree-cmd`  it is now possible to display the full command line arguments in the process tree.

Example:

```bash
$ checkpointctl inspect /path/to/checkpoint.tar.gz --ps-tree-cmd
counter
└── [1]  bash
    ├── [7]  bash -c 'python counter.py'
    ├── [8]  python counter.py --input data.txt --output result.txt
    ├── [11]  bash -c 'tee output.log'
    └── [20]  tee output.log
``` 