### PR TITLE
feat: display process tree with environment variables

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -20,6 +20,7 @@ var (
 	pID       uint32
 	psTree    bool
 	psTreeCmd bool
+	psTreeEnv bool
 	files     bool
 	showAll   bool
 )
@@ -111,6 +112,12 @@ func setupInspect() *cobra.Command {
 		"Display an overview of processes in the container checkpoint with full command line arguments",
 	)
 	flags.BoolVar(
+		&psTreeEnv,
+		"ps-tree-env",
+		false,
+		"Display an overview of processes in the container checkpoint with their environment variables",
+	)
+	flags.BoolVar(
 		&files,
 		"files",
 		false,
@@ -168,8 +175,8 @@ func inspect(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	if psTreeCmd {
-		// Enable displaying process tree when using --ps-tree-cmd.
+	if psTreeCmd || psTreeEnv {
+		// Enable displaying process tree when using --ps-tree-cmd or --ps-tree-env.
 		psTree = true
 		requiredFiles = append(
 			requiredFiles,

--- a/container.go
+++ b/container.go
@@ -328,3 +328,23 @@ func getCmdline(checkpointOutputDir string, pid uint32) (cmdline string, err err
 	cmdline = strings.Join(strings.Split(buffer.String(), "\x00"), " ")
 	return
 }
+
+func getPsEnvVars(checkpointOutputDir string, pid uint32) (envVars []string, err error) {
+	mr, err := crit.NewMemoryReader(filepath.Join(checkpointOutputDir, metadata.CheckpointDirectory), pid, pageSize)
+	if err != nil {
+		return
+	}
+
+	buffer, err := mr.GetPsEnvVars()
+	if err != nil {
+		return
+	}
+
+	for _, envVar := range strings.Split(buffer.String(), "\x00") {
+		if envVar != "" {
+			envVars = append(envVars, envVar)
+		}
+	}
+
+	return
+}

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -315,6 +315,37 @@ function teardown() {
 	[[ ${lines[0]} == *"failed to process command line arguments"* ]]
 }
 
+@test "Run checkpointctl inspect with tar file and --ps-tree-env" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/pages-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree-env
+	[ "$status" -eq 0 ]
+	[[ ${lines[8]} == *"Process tree"* ]]
+	[[ ${lines[9]} == *"piggie"* ]]
+	[[ ${lines[10]} == *"="* ]]
+}
+
+@test "Run checkpointctl inspect with tar file and --ps-tree-env and missing pages-*.img {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree-env
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"no such file or directory"* ]]
+}
+
 @test "Run checkpointctl inspect with tar file and --files" {
 	cp data/config.dump \
 		data/spec.dump "$TEST_TMP_DIR1"


### PR DESCRIPTION
This commit introduces a new flag, --ps-tree-env, which enables the display of process environment variables in the process tree output.

Example output:

```bash
$ checkpointctl inspect --ps-tree-cmd /path/to/checkpoint.tar.gz 

Displaying container checkpoint tree view from /home/behouba/checkpoints/httpd.tar.gz

httpd
├── Image: docker.io/library/httpd:2.4
├── ID: 4f6831a7e8e641e75578704cb90bcbd987b6d9655404b58f5cbf954d042f3212
├── Runtime: crun
├── Created: 2023-07-22T13:14:49+03:00
├── Engine: Podman
├── Checkpoint size: 5.2 MiB
├── Root FS diff size: 2.0 KiB
└── Process tree
    └── [1]  httpd
        ├── HTTPD_VERSION=2.4.57
        ├── HOSTNAME=4f6831a7e8e6
        ├── HOME=/root
        ├── HTTPD_PATCHES=rewrite-windows-testchar-h.patch 1d5620574fa03b483262dc5b9a66a6906553389952ab5d3070a02f887cc20193
        ├── container=podman
        ├── TERM=xterm
        ├── PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
        ├── HTTPD_SHA256=dbccb84aee95e095edfbb81e5eb926ccd24e6ada55dcd83caecb262e5cf94d2a
        ├── HTTPD_PREFIX=/usr/local/apache2
        ├── PWD=/usr/local/apache2
        ├── [4]  httpd
        │   ├── HTTPD_VERSION=2.4.57
        │   ├── HOSTNAME=4f6831a7e8e6
        │   ├── HOME=/root
        │   ├── HTTPD_PATCHES=rewrite-windows-testchar-h.patch 1d5620574fa03b483262dc5b9a66a6906553389952ab5d3070a02f887cc20193
        │   ├── container=podman
        │   ├── TERM=xterm
        │   ├── PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
        │   ├── HTTPD_SHA256=dbccb84aee95e095edfbb81e5eb926ccd24e6ada55dcd83caecb262e5cf94d2a
        │   ├── HTTPD_PREFIX=/usr/local/apache2
        │   └── PWD=/usr/local/apache2
```