### PR TITLE
fix: remove `us` for pages scanned and pages written

### DIFF
--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -247,7 +247,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ ${lines[8]} == *"CRIU dump statistics"* ]]
 	[[ ${lines[12]} == *"Memwrite time"* ]]
-	[[ ${lines[13]} =~ [1-9]+" us" ]]
+	[[ ${lines[13]} =~ [1-9] ]]
 }
 
 @test "Run checkpointctl inspect with tar file and --mounts and valid spec.dump" {
@@ -356,7 +356,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ ${lines[8]} == *"CRIU dump statistics"* ]]
 	[[ ${lines[12]} == *"Memwrite time"* ]]
-	[[ ${lines[13]} =~ [1-9]+" us" ]]
+	[[ ${lines[13]} =~ [1-9] ]]
 	[[ ${lines[15]} == *"Process tree"* ]]
 	[[ ${lines[16]} == *"piggie"* ]]
 	[[ ${lines[17]} == *"[REG 0]"* ]]

--- a/tree.go
+++ b/tree.go
@@ -108,8 +108,8 @@ func addDumpStatsToTree(tree treeprint.Tree, dumpStats *stats_pb.DumpStatsEntry)
 	statsTree.AddBranch(fmt.Sprintf("Frozen time: %d us", dumpStats.GetFrozenTime()))
 	statsTree.AddBranch(fmt.Sprintf("Memdump time: %d us", dumpStats.GetMemdumpTime()))
 	statsTree.AddBranch(fmt.Sprintf("Memwrite time: %d us", dumpStats.GetMemwriteTime()))
-	statsTree.AddBranch(fmt.Sprintf("Pages scanned: %d us", dumpStats.GetPagesScanned()))
-	statsTree.AddBranch(fmt.Sprintf("Pages written: %d us", dumpStats.GetPagesWritten()))
+	statsTree.AddBranch(fmt.Sprintf("Pages scanned: %d", dumpStats.GetPagesScanned()))
+	statsTree.AddBranch(fmt.Sprintf("Pages written: %d", dumpStats.GetPagesWritten()))
 }
 
 func addPsTreeToTree(tree treeprint.Tree, psTree *crit.PsTree) error {


### PR DESCRIPTION
This PR removes the 'us' unit for 'pages scanned' and 'pages written' in the dump statistics tree node.

Fixes: #91 