### PR TITLE
feat: add `memparse` sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Details on how to create checkpoints with the help of [CRIU][criu] can be found 
 
 ## Usage
 
+### `show` sub-command
+
 To display an overview of a checkpoint archive you can just use
 `checkpointctl show`:
 
@@ -41,6 +43,8 @@ $ checkpointctl show /var/lib/kubelet/checkpoints/checkpoint-counters_default-co
 +-----------+------------------------------------+--------------+---------+--------------------------------+--------+------------+------------+
 ```
 
+### `inspect` sub-command
+
 To retrieve low-level information about a container checkpoint, use the `checkpointctl inspect` command:
 
 ```console
@@ -63,6 +67,91 @@ awesome_booth
 ```
 
 For a complete list of flags supported, use `checkpointctl inspect --help`.
+
+### `memparse` sub-command
+
+To perform memory analysis of container checkpoints, you can use the `checkpointctl memparse` command.
+
+```console
+$ checkpointctl memparse /tmp/jira.tar.gz  --pid=1 | less
+
+Displaying memory pages content for Process ID 1 from checkpoint: /tmp/jira.tar.gz
+
+Address           Hexadecimal                                       ASCII            
+-------------------------------------------------------------------------------------
+00005633bb080000  f3 0f 1e fa 48 83 ec 08 48 8b 05 d1 4f 00 00 48  |....H...H...O..H|
+00005633bb080010  85 c0 74 02 ff d0 48 83 c4 08 c3 00 00 00 00 00  |..t...H.........|
+00005633bb080020  ff 35 b2 4e 00 00 f2 ff 25 b3 4e 00 00 0f 1f 00  |.5.N....%.N.....|
+00005633bb080030  f3 0f 1e fa 68 00 00 00 00 f2 e9 e1 ff ff ff 90  |....h...........|
+*
+00005633bb0800a0  f3 0f 1e fa 68 07 00 00 00 f2 e9 71 ff ff ff 90  |....h......q....|
+00005633bb0800b0  f3 0f 1e fa 68 08 00 00 00 f2 e9 61 ff ff ff 90  |....h......a....|
+00005633bb0800c0  f3 0f 1e fa 68 09 00 00 00 f2 e9 51 ff ff ff 90  |....h......Q....|
+00005633bb0800d0  f3 0f 1e fa 68 0a 00 00 00 f2 e9 41 ff ff ff 90  |....h......A....|
+00005633bb0800e0  f3 0f 1e fa 68 0b 00 00 00 f2 e9 31 ff ff ff 90  |....h......1....|
+```
+
+Here's an example of memory analysis of a PostgreSQL container. In this case, we start a PostgreSQL container with a password set to 'mysecret'. Then, we create a checkpoint of the container and use the `memparse` to find the stored password.
+
+```console
+$ sudo podman run --name postgres -e POSTGRES_PASSWORD=mysecret -d postgres
+$ sudo podman container checkpoint -l --export=/tmp/postgres.tar.gz
+$ sudo checkpointctl memparse --pid 1 /tmp/postgres.tar.gz | grep -B 1 -A 1 mysecret
+000055dd725c1e60  50 4f 53 54 47 52 45 53 5f 50 41 53 53 57 4f 52  |POSTGRES_PASSWOR|
+000055dd725c1e70  44 3d 6d 79 73 65 63 72 65 74 00 00 00 00 00 00  |D=mysecret......|
+000055dd725c1e80  00 00 00 00 00 00 00 00 31 00 00 00 00 00 00 00  |........1.......|
+```
+
+Here's another scenario, of memory analysis for a web application container. We start a vulnerable web application container, perform an arbitrary code execution attack, create a checkpoint for forensic analysis while leaving the container running, and finally analyze the checkpoint memory to identify the injected code.
+
+```console
+# Start vulnerable web application
+$ sudo podman run --name dsvw -p 1234:8000 -d quay.io/rst0git/dsvw
+
+# Perform arbitrary code execution attack: $(echo secret)
+$ curl "http://localhost:1234/?domain=www.google.com%3B%20echo%20secret"
+nslookup: can't resolve '(null)': Name does not resolve
+
+Name:      www.google.com
+Address 1: 142.250.187.228 lhr25s34-in-f4.1e100.net
+Address 2: 2a00:1450:4009:820::2004 lhr25s34-in-x04.1e100.net
+secret
+(reverse-i-search)`': ^C
+
+# Create a checkpoint for forensic analysis and leave the container running
+$ sudo podman container checkpoint --leave-running -l -e /tmp/dsvw.tar
+
+# Analyse checkpoint memory to identify the attacker's injected code
+$ sudo checkpointctl memparse --pid 1 /tmp/dsvw.tar | grep 'echo secret'
+00007faac5711f60  6f 6d 3b 20 65 63 68 6f 20 73 65 63 72 65 74 00  |om; echo secret.|
+```
+
+For larger processes, it's recommended to write the contents of process memory pages to a file rather than standard output.
+
+To get an overview of process memory sizes within the checkpoint, run `checkpointctl memparse` without arguments.
+
+```console
+$ sudo checkpointctl memparse /tmp/jira.tar.gz
+
+Displaying processes memory sizes from /tmp/jira.tar.gz
+
++-----+--------------+-------------+
+| PID | PROCESS NAME | MEMORY SIZE |
++-----+--------------+-------------+
+|   1 | tini         | 100.0 KiB   |
++-----+--------------+-------------+
+|   2 | java         | 553.5 MiB   |
++-----+--------------+-------------+
+```
+
+In this example, given the large size of the java process, it is better to write its output to a file.
+
+```console
+$ sudo checkpointctl memparse --pid=2 /tmp/jira.tar.gz --output=/tmp/java-memory-pages.txt
+Writing memory pages content for process ID 2 from checkpoint: /tmp/jira.tar.gz to file: /tmp/java-memory-pages.txt...
+```
+
+Please note that writing large memory pages to a file can take several minutes.
 
 ## Installing from source code
 

--- a/memparse.go
+++ b/memparse.go
@@ -5,7 +5,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -13,6 +15,10 @@ import (
 	"github.com/checkpoint-restore/go-criu/v6/crit"
 	"github.com/olekukonko/tablewriter"
 )
+
+// chunkSize represents the default size of memory chunk (in bytes)
+// to read for each output line when printing memory pages content in hexdump-like format.
+const chunkSize = 16
 
 // Display processes memory sizes within the given container checkpoints.
 func showProcessMemorySizeTables(tasks []task) error {
@@ -80,4 +86,117 @@ func showProcessMemorySizeTables(tasks []task) error {
 	}
 
 	return nil
+}
+
+func printProcessMemoryPages(task task) error {
+	c := crit.New(nil, nil, filepath.Join(task.outputDir, metadata.CheckpointDirectory), false, false)
+	psTree, err := c.ExplorePs()
+	if err != nil {
+		return fmt.Errorf("failed to get process tree: %w", err)
+	}
+
+	// Check if PID exist within the checkpoint
+	if pID != 0 {
+		ps := psTree.FindPs(pID)
+		if ps == nil {
+			return fmt.Errorf("no process with PID %d (use `inspect --ps-tree` to view all PIDs)", pID)
+		}
+	}
+
+	memReader, err := crit.NewMemoryReader(
+		filepath.Join(task.outputDir, metadata.CheckpointDirectory),
+		pID, pageSize,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Unpack pages-[pagesID].img file for the given PID
+	if err := untarFiles(
+		task.checkpointFilePath, task.outputDir,
+		[]string{filepath.Join(metadata.CheckpointDirectory, fmt.Sprintf("pages-%d.img", memReader.GetPagesID()))},
+	); err != nil {
+		return err
+	}
+
+	// Write the output to stdout by default
+	var output io.Writer = os.Stdout
+	var compact bool
+
+	if outputFilePath != "" {
+		// Write to ouput to file if --output is specified
+		f, err := os.Create(outputFilePath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		output = f
+		fmt.Printf("\nWriting memory pages content for process ID %d from checkpoint: %s to file: %s...\n",
+			pID, task.checkpointFilePath, outputFilePath,
+		)
+	} else {
+		compact = true // Use a compact format when writing the output to stdout
+		fmt.Printf("\nDisplaying memory pages content for process ID %d from checkpoint: %s\n\n", pID, task.checkpointFilePath)
+	}
+
+	fmt.Fprintln(output, "Address           Hexadecimal                                       ASCII            ")
+	fmt.Fprintln(output, "-------------------------------------------------------------------------------------")
+
+	pagemapEntries := memReader.GetPagemapEntries()
+	for _, entry := range pagemapEntries {
+		start := entry.GetVaddr()
+		end := start + (uint64(pageSize) * uint64(entry.GetNrPages()))
+		buf, err := memReader.GetMemPages(start, end)
+		if err != nil {
+			return err
+		}
+
+		hexdump(output, buf, start, compact)
+	}
+	return nil
+}
+
+// hexdump generates a hexdump of the buffer 'buf' starting at the virtual address 'start'
+// and writes the output to 'out'. If compact is true, consecutive duplicate rows will be represented
+// with an asterisk (*).
+func hexdump(out io.Writer, buf *bytes.Buffer, vaddr uint64, compact bool) {
+	var prevAscii string
+	var isDuplicate bool
+	for buf.Len() > 0 {
+		row := buf.Next(chunkSize)
+		hex, ascii := generateHexAndAscii(row)
+
+		if compact {
+			if prevAscii == ascii {
+				if !isDuplicate {
+					fmt.Fprint(out, "*\n")
+				}
+				isDuplicate = true
+			} else {
+				fmt.Fprintf(out, "%016x  %s |%s|\n", vaddr, hex, ascii)
+				isDuplicate = false
+			}
+		} else {
+			fmt.Fprintf(out, "%016x  %s |%s|\n", vaddr, hex, ascii)
+		}
+
+		vaddr += chunkSize
+		prevAscii = ascii
+	}
+}
+
+// generateHexAndAscii takes a byte slice and generates its hexadecimal and ASCII representations.
+func generateHexAndAscii(data []byte) (string, string) {
+	var hex, ascii string
+	for i := 0; i < len(data); i++ {
+		if data[i] < 32 || data[i] >= 127 {
+			ascii += "."
+			hex += fmt.Sprintf("%02x ", data[i])
+		} else {
+			ascii += string(data[i])
+			hex += fmt.Sprintf("%02x ", data[i])
+		}
+	}
+
+	return hex, ascii
 }

--- a/memparse.go
+++ b/memparse.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is used to handle memory pages analysis of container checkpoints
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	metadata "github.com/checkpoint-restore/checkpointctl/lib"
+	"github.com/checkpoint-restore/go-criu/v6/crit"
+	"github.com/olekukonko/tablewriter"
+)
+
+// Display processes memory sizes within the given container checkpoints.
+func showProcessMemorySizeTables(tasks []task) error {
+	// Initialize the table
+	table := tablewriter.NewWriter(os.Stdout)
+	header := []string{
+		"PID",
+		"Process name",
+		"Memory size",
+	}
+	table.SetHeader(header)
+	table.SetAutoMergeCells(false)
+	table.SetRowLine(true)
+
+	// Function to recursively traverse the process tree and populate the table rows
+	var traverseTree func(*crit.PsTree, string) error
+	traverseTree = func(root *crit.PsTree, checkpointOutputDir string) error {
+		memReader, err := crit.NewMemoryReader(
+			filepath.Join(checkpointOutputDir, metadata.CheckpointDirectory),
+			root.PID, pageSize,
+		)
+		if err != nil {
+			return err
+		}
+
+		pagemapEntries := memReader.GetPagemapEntries()
+
+		var memSize int64
+
+		for _, entry := range pagemapEntries {
+			memSize += int64(*entry.NrPages) * int64(pageSize)
+		}
+
+		table.Append([]string{
+			fmt.Sprintf("%d", root.PID),
+			root.Comm,
+			metadata.ByteToString(memSize),
+		})
+
+		for _, child := range root.Children {
+			if err := traverseTree(child, checkpointOutputDir); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, task := range tasks {
+		// Clear the table before processing each checkpoint task
+		table.ClearRows()
+
+		c := crit.New(nil, nil, filepath.Join(task.outputDir, "checkpoint"), false, false)
+		psTree, err := c.ExplorePs()
+		if err != nil {
+			return fmt.Errorf("failed to get process tree: %w", err)
+		}
+
+		// Populate the table rows
+		if err := traverseTree(psTree, task.outputDir); err != nil {
+			return err
+		}
+
+		fmt.Printf("\nDisplaying processes memory sizes from %s\n\n", task.checkpointFilePath)
+		table.Render()
+	}
+
+	return nil
+}

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -506,3 +506,60 @@ function teardown() {
 	[[ ${lines[6]} == *"Podman"* ]]
 	[[ ${lines[14]} == *"Podman"* ]]
 }
+
+@test "Run checkpointctl memparse with tar file" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl memparse "$TEST_TMP_DIR2"/test.tar
+	[ "$status" -eq 0 ]
+	[[ ${lines[4]} == *"piggie"* ]]
+}
+
+@test "Run checkpointctl memparse with tar file and missing pstree.img" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl memparse "$TEST_TMP_DIR2"/test.tar
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"no such file or directory"* ]]
+}
+
+@test "Run checkpointctl memparse with tar file and valid PID" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/pages-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl memparse "$TEST_TMP_DIR2"/test.tar --pid=1
+	[ "$status" -eq 0 ]
+	[[ ${lines[3]} == *"....H...H.../..H"* ]]
+}
+
+@test "Run checkpointctl memparse with tar file and invalid PID" {
+	cp data/config.dump \
+		data/spec.dump "$TEST_TMP_DIR1"
+	mkdir "$TEST_TMP_DIR1"/checkpoint
+	cp test-imgs/pstree.img \
+		test-imgs/core-*.img \
+		test-imgs/pagemap-*.img \
+		test-imgs/pages-*.img \
+		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
+	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
+	checkpointctl memparse "$TEST_TMP_DIR2"/test.tar --pid=9999 
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} == *"no process with PID 9999"* ]]
+}

--- a/tree.go
+++ b/tree.go
@@ -121,21 +121,7 @@ func addDumpStatsToTree(tree treeprint.Tree, dumpStats *stats_pb.DumpStatsEntry)
 func addPsTreeToTree(tree treeprint.Tree, psTree *crit.PsTree, checkpointOutputDir string) error {
 	psRoot := psTree
 	if pID != 0 {
-		// dfs performs a short-circuiting depth-first search.
-		var dfs func(*crit.PsTree) *crit.PsTree
-		dfs = func(root *crit.PsTree) *crit.PsTree {
-			if root.PID == pID {
-				return root
-			}
-			for _, child := range root.Children {
-				if ps := dfs(child); ps != nil {
-					return ps
-				}
-			}
-			return nil
-		}
-
-		ps := dfs(psTree)
+		ps := psTree.FindPs(pID)
 		if ps == nil {
 			return fmt.Errorf("no process with PID %d (use `inspect --ps-tree` to view all PIDs)", pID)
 		}


### PR DESCRIPTION
This PR introduces a new sub-command `memparse` ,  which allows analyzing processes memory pages. 
This new feature was discussed here #69. 

When used without any arguments, the command displays a table showing the memory sizes of processes. Here's an example:
```bash
$ checkpointctl memparse /path/to/checkpoints/jira.tar.gz 

Displaying processes memory sizes from /home/behouba/checkpoints/jira.tar.gz

+-----+--------------+-------------+
| PID | PROCESS NAME | MEMORY SIZE |
+-----+--------------+-------------+
|   1 | tini         | 100.0 KiB   |
+-----+--------------+-------------+
|   2 | java         | 553.5 MiB   |
+-----+--------------+-------------+
```

If a process ID (pid) is provided, the command prints the memory pages of that specific process in a hexdump-like format. For instance:

```bash
$ checkpointctl memparse /path/to/checkpoints/jira.tar.gz  --pid=1 | less

Displaying memory pages content for Process ID 1 from checkpoint: /home/behouba/checkpoints/jira.tar.gz

Address           Hexadecimal                                       ASCII            
-------------------------------------------------------------------------------------
00005633bb080000  f3 0f 1e fa 48 83 ec 08 48 8b 05 d1 4f 00 00 48  |....H...H...O..H|
00005633bb080010  85 c0 74 02 ff d0 48 83 c4 08 c3 00 00 00 00 00  |..t...H.........|
00005633bb080020  ff 35 b2 4e 00 00 f2 ff 25 b3 4e 00 00 0f 1f 00  |.5.N....%.N.....|
00005633bb080030  f3 0f 1e fa 68 00 00 00 00 f2 e9 e1 ff ff ff 90  |....h...........|
*
00005633bb0800a0  f3 0f 1e fa 68 07 00 00 00 f2 e9 71 ff ff ff 90  |....h......q....|
00005633bb0800b0  f3 0f 1e fa 68 08 00 00 00 f2 e9 61 ff ff ff 90  |....h......a....|
00005633bb0800c0  f3 0f 1e fa 68 09 00 00 00 f2 e9 51 ff ff ff 90  |....h......Q....|
00005633bb0800d0  f3 0f 1e fa 68 0a 00 00 00 f2 e9 41 ff ff ff 90  |....h......A....|
00005633bb0800e0  f3 0f 1e fa 68 0b 00 00 00 f2 e9 31 ff ff ff 90  |....h......1....|
````
This output can be written to a file instead of stdout using the `--output` flag.

@rst0git, @adrianreber, could you please take a look?