### PR TITLE
inspect: enable --ps-tree-{env,cmd} with --all

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -143,7 +143,8 @@ func inspect(cmd *cobra.Command, args []string) error {
 	if showAll {
 		stats = true
 		mounts = true
-		psTree = true
+		psTreeCmd = true
+		psTreeEnv = true
 		files = true
 	}
 


### PR DESCRIPTION
This patch enables `--ps-tree-cmd` and `--ps-tree-env` options when the `inspect` command is used with `--all`. This change provides more complete information about the processes included in a container checkpoint.