### PR TITLE
stats: use time units in human-friendly format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ shellcheck:
 lint: golang-lint shellcheck
 
 test: $(NAME)
+	$(GO) test -v ./...
 	make -C test
 
 test-junit: $(NAME)

--- a/tree.go
+++ b/tree.go
@@ -110,10 +110,10 @@ func addMountsToTree(tree treeprint.Tree, specDump *spec.Spec) {
 
 func addDumpStatsToTree(tree treeprint.Tree, dumpStats *stats_pb.DumpStatsEntry) {
 	statsTree := tree.AddBranch("CRIU dump statistics")
-	statsTree.AddBranch(fmt.Sprintf("Freezing time: %d us", dumpStats.GetFreezingTime()))
-	statsTree.AddBranch(fmt.Sprintf("Frozen time: %d us", dumpStats.GetFrozenTime()))
-	statsTree.AddBranch(fmt.Sprintf("Memdump time: %d us", dumpStats.GetMemdumpTime()))
-	statsTree.AddBranch(fmt.Sprintf("Memwrite time: %d us", dumpStats.GetMemwriteTime()))
+	statsTree.AddBranch(fmt.Sprintf("Freezing time: %s", FormatTime(dumpStats.GetFreezingTime())))
+	statsTree.AddBranch(fmt.Sprintf("Frozen time: %s", FormatTime(dumpStats.GetFrozenTime())))
+	statsTree.AddBranch(fmt.Sprintf("Memdump time: %s", FormatTime(dumpStats.GetMemdumpTime())))
+	statsTree.AddBranch(fmt.Sprintf("Memwrite time: %s", FormatTime(dumpStats.GetMemwriteTime())))
 	statsTree.AddBranch(fmt.Sprintf("Pages scanned: %d", dumpStats.GetPagesScanned()))
 	statsTree.AddBranch(fmt.Sprintf("Pages written: %d", dumpStats.GetPagesWritten()))
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func FormatTime(microseconds uint32) string {
+	if microseconds < 1000 {
+		return fmt.Sprintf("%d µs", microseconds)
+	}
+
+	var value float64
+	var unit string
+
+	if microseconds < 1000000 {
+		value = float64(microseconds) / 1000
+		unit = "ms"
+	} else {
+		duration := time.Duration(microseconds) * time.Microsecond
+		value = duration.Seconds()
+		unit = "s"
+	}
+
+	// Trim trailing zeros and dot
+	formatted := strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.5g", value), "0"), ".")
+
+	return fmt.Sprintf("%s %s", formatted, unit)
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFormatTime(t *testing.T) {
+	tests := []struct {
+		input    uint32
+		expected string
+	}{
+		{1, "1 µs"},
+		{500, "500 µs"},
+		{999, "999 µs"},
+		{1001, "1.001 ms"},
+		{1100, "1.1 ms"},
+		{13400, "13.4 ms"},
+		{1340001, "1.34 s"},
+		{1340520, "1.3405 s"},
+		{1340560, "1.3406 s"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Input-%d", test.input), func(t *testing.T) {
+			result := FormatTime(test.input)
+			if result != test.expected {
+				t.Errorf("Expected %s, but got %s", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request transforms the CRIU statistics into human-readable format.

Example:
```
httpd
├── Image: docker.io/library/httpd:2.4
├── ID: 04b6be846ef4535bf9027ae36b7f3efeda78f2c314c4d9694b09da70db042b88
├── Runtime: crun
├── Created: 2023-08-07T13:02:38+01:00
├── Engine: Podman
├── Checkpoint size: 5.2 MiB
├── Root FS diff size: 2.0 KiB
└── CRIU dump statistics
    ├── Freezing time: 3.781 ms
    ├── Frozen time: 116.54 ms
    ├── Memdump time: 22.666 ms
    ├── Memwrite time: 3.382 ms
    ├── Pages scanned: 1498870
    └── Pages written: 1213
```