### PR TITLE
inspect: show size of memory pages

### DIFF
--- a/container.go
+++ b/container.go
@@ -201,6 +201,8 @@ func hasPrefix(path, prefix string) bool {
 type archiveSizes struct {
 	checkpointSize    int64
 	rootFsDiffTarSize int64
+	pagesSize         int64
+	amdgpuPagesSize   int64
 }
 
 // getArchiveSizes calculates the sizes of different components within a container checkpoint.
@@ -212,6 +214,11 @@ func getArchiveSizes(archiveInput string) (*archiveSizes, error) {
 			if hasPrefix(header.Name, metadata.CheckpointDirectory) {
 				// Add the file size to the total checkpoint size
 				result.checkpointSize += header.Size
+				if hasPrefix(header.Name, filepath.Join(metadata.CheckpointDirectory, metadata.PagesPrefix)) {
+					result.pagesSize += header.Size
+				} else if hasPrefix(header.Name, filepath.Join(metadata.CheckpointDirectory, metadata.AmdgpuPagesPrefix)) {
+					result.amdgpuPagesSize += header.Size
+				}
 			} else if hasPrefix(header.Name, metadata.RootFsDiffTar) {
 				// Read the size of rootfs diff
 				result.rootFsDiffTarSize = header.Size

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -29,6 +29,9 @@ const (
 	PodDumpFile    = "pod.dump"
 	// containerd only
 	StatusFile = "status"
+	// CRIU Images
+	PagesPrefix       = "pages-"
+	AmdgpuPagesPrefix = "amdgpu-pages-"
 )
 
 // This is a reduced copy of what Podman uses to store checkpoint metadata

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -297,8 +297,8 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree-cmd
 	[ "$status" -eq 0 ]
-	[[ ${lines[8]} == *"Process tree"* ]]
-	[[ ${lines[9]} == *"piggie/piggie"* ]]
+	[[ ${lines[9]} == *"Process tree"* ]]
+	[[ ${lines[10]} == *"piggie/piggie"* ]]
 }
 
 @test "Run checkpointctl inspect with tar file and --ps-tree-cmd and missing pages-*.img {
@@ -327,9 +327,9 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --ps-tree-env
 	[ "$status" -eq 0 ]
-	[[ ${lines[8]} == *"Process tree"* ]]
-	[[ ${lines[9]} == *"piggie"* ]]
-	[[ ${lines[10]} == *"="* ]]
+	[[ ${lines[9]} == *"Process tree"* ]]
+	[[ ${lines[10]} == *"piggie"* ]]
+	[[ ${lines[11]} == *"="* ]]
 }
 
 @test "Run checkpointctl inspect with tar file and --ps-tree-env and missing pages-*.img {
@@ -420,11 +420,11 @@ function teardown() {
 	run checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --all
 	[ "$status" -eq 0 ]
 
-	[[ ${lines[8]} == *"CRIU dump statistics"* ]]
-	[[ ${lines[12]} == *"Memwrite time"* ]]
-	[[ ${lines[13]} =~ [1-9] ]]
-	[[ ${lines[15]} == *"Process tree"* ]]
-	[[ ${lines[16]} == *"piggie"* ]]
+	[[ ${lines[9]} == *"CRIU dump statistics"* ]]
+	[[ ${lines[13]} == *"Memwrite time"* ]]
+	[[ ${lines[14]} =~ [1-9] ]]
+	[[ ${lines[16]} == *"Process tree"* ]]
+	[[ ${lines[17]} == *"piggie"* ]]
 
 	expected_messages=(
 		"[REG 0]"
@@ -559,7 +559,7 @@ function teardown() {
 		test-imgs/pages-*.img \
 		test-imgs/mm-*.img "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
-	checkpointctl memparse "$TEST_TMP_DIR2"/test.tar --pid=9999 
+	checkpointctl memparse "$TEST_TMP_DIR2"/test.tar --pid=9999
 	[ "$status" -eq 1 ]
 	[[ ${lines[0]} == *"no process with PID 9999"* ]]
 }

--- a/tree.go
+++ b/tree.go
@@ -88,7 +88,13 @@ func buildTree(ci *containerInfo, containerConfig *metadata.ContainerConfig, arc
 		tree.AddBranch(fmt.Sprintf("MAC: %s", ci.MAC))
 	}
 
-	tree.AddBranch(fmt.Sprintf("Checkpoint size: %s", metadata.ByteToString(archiveSizes.checkpointSize)))
+	checkpointSize := tree.AddBranch(fmt.Sprintf("Checkpoint size: %s", metadata.ByteToString(archiveSizes.checkpointSize)))
+	if archiveSizes.pagesSize != 0 {
+		checkpointSize.AddNode(fmt.Sprintf("Memory pages size: %s", metadata.ByteToString(archiveSizes.pagesSize)))
+	}
+	if archiveSizes.amdgpuPagesSize != 0 {
+		checkpointSize.AddNode(fmt.Sprintf("AMD GPU memory pages size: %s", metadata.ByteToString(archiveSizes.amdgpuPagesSize)))
+	}
 
 	if archiveSizes.rootFsDiffTarSize != 0 {
 		tree.AddBranch(fmt.Sprintf("Root FS diff size: %s", metadata.ByteToString(archiveSizes.rootFsDiffTarSize)))


### PR DESCRIPTION
This pull request extends the `checkpointctl inspect` command to display the size of memory pages and GPU memory as sub-nodes of *checkpoint size*.

Example:

```
rocm-matrix-multiplication-container
├── Image: quay.io/radostin/rocm-matrix-multiplication:latest
├── ID: 453745dcea71ec3a303242a44452b60118d8be1a3aa9a2cf8c6cae1aaf9855f4
├── Runtime: runc
├── Created: 2023-08-11T09:45:00.63222499+01:00
├── Engine: CRI-O
├── IP: 10.85.0.12
├── Checkpoint size: 28.4 GiB
│   ├── Memory pages size: 28.3 GiB
│   └── AMD GPU memory pages size: 140.1 MiB
└── Root FS diff size: 2.5 KiB
```
```
jira
├── Image: docker.io/atlassian/jira-software:latest
├── ID: 3f731c3a3951e25cc6509a3d49d7e8b799dc14dec4a96abb95e1ece55fb1692c
├── Runtime: crun
├── Created: 2023-08-11T10:24:48+01:00
├── Engine: Podman
├── Checkpoint size: 495.1 MiB
│   └── Memory pages size: 494.9 MiB
└── Root FS diff size: 74.5 KiB
```