### PR TITLE
tree: use sub-nodes for open files and env vars

### DIFF
--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -329,7 +329,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ ${lines[9]} == *"Process tree"* ]]
 	[[ ${lines[10]} == *"piggie"* ]]
-	[[ ${lines[11]} == *"="* ]]
+	[[ ${lines[12]} == *"="* ]]
 }
 
 @test "Run checkpointctl inspect with tar file and --ps-tree-env and missing pages-*.img {
@@ -359,9 +359,9 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --files
 	[ "$status" -eq 0 ]
-	[[ ${lines[10]} == *"[REG 0]"* ]]
-	[[ ${lines[11]} == *"[cwd]"* ]]
-	[[ ${lines[12]} == *"[root]"* ]]
+	[[ ${lines[11]} == *"[REG 0]"* ]]
+	[[ ${lines[12]} == *"[cwd]"* ]]
+	[[ ${lines[13]} == *"[root]"* ]]
 }
 
 @test "Run checkpointctl inspect with tar file and --files and missing files.img" {

--- a/tree.go
+++ b/tree.go
@@ -147,8 +147,9 @@ func addPsTreeToTree(tree treeprint.Tree, psTree *crit.PsTree, checkpointOutputD
 				return err
 			}
 
+			nodeSubtree := node.AddBranch("Environment variables")
 			for _, env := range envVars {
-				node.AddBranch(env)
+				nodeSubtree.AddBranch(env)
 			}
 		}
 		for _, child := range root.Children {
@@ -173,8 +174,9 @@ func addFdsToTree(tree treeprint.Tree, fds []*crit.Fd) {
 		if node == nil {
 			continue
 		}
+		nodeSubtree := node.AddBranch("Open files")
 		for _, file := range fd.Files {
-			node.AddMetaBranch(strings.TrimSpace(file.Type+" "+file.Fd), file.Path)
+			nodeSubtree.AddMetaBranch(strings.TrimSpace(file.Type+" "+file.Fd), file.Path)
 		}
 	}
 }


### PR DESCRIPTION
When using inspect with `--all`, the information about open files and environment variables appears in format that may not be easy for users to interpret and understand. This pull request adds appropriate labels to address this issue.

Example:

```
├── Process tree
│   └── [1]  /bin/sh -c i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done
│       ├── Environment variables
│       │   ├── container=podman
│       │   ├── PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
│       │   ├── TERM=xterm
│       │   ├── HOME=/root
│       │   └── HOSTNAME=a8e8196b24f8
│       └── Open files
│           ├── [REG 0]  /dev/null
│           ├── [PIPE 1]  pipe[1654003]
│           ├── [PIPE 2]  pipe[1654004]
│           ├── [cwd]  /
│           └── [root]  /
```