### PR TITLE
memparse: show process shared memory size

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -327,6 +327,7 @@ func memparse(cmd *cobra.Command, args []string) error {
 		requiredFiles = append(
 			requiredFiles,
 			filepath.Join(metadata.CheckpointDirectory, "pagemap-"),
+			filepath.Join(metadata.CheckpointDirectory, "mm-"),
 		)
 	} else {
 		requiredFiles = append(

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/checkpoint-restore/checkpointctl
 go 1.18
 
 require (
-	github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230807192453-2210c022f3aa
+	github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230822084504-f3c069bb94de
 	github.com/containers/storage v1.48.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/runtime-spec v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230807192453-2210c022f3aa h1:1tLroyhJa0TAcT/+M37a4Uzh3tC90ForvkA1MymOi1c=
-github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230807192453-2210c022f3aa/go.mod h1:2tn0Jd4/R94ab1JR/OYdh0QXnM1RNN+OCkDYGQKCbFg=
+github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230822084504-f3c069bb94de h1:EWaQXnhXTEaaZeJObDoHPAxvhp9zvD55V8qldfxvEiw=
+github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230822084504-f3c069bb94de/go.mod h1:2tn0Jd4/R94ab1JR/OYdh0QXnM1RNN+OCkDYGQKCbFg=
 github.com/containers/storage v1.48.0 h1:wiPs8J2xiFoOEAhxHDRtP6A90Jzj57VqzLRXOqeizns=
 github.com/containers/storage v1.48.0/go.mod h1:pRp3lkRo2qodb/ltpnudoXggrviRmaCmU5a5GhTBae0=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/memparse.go
+++ b/memparse.go
@@ -28,6 +28,7 @@ func showProcessMemorySizeTables(tasks []task) error {
 		"PID",
 		"Process name",
 		"Memory size",
+		"Shared memory size",
 	}
 	table.SetHeader(header)
 	table.SetAutoMergeCells(false)
@@ -52,10 +53,16 @@ func showProcessMemorySizeTables(tasks []task) error {
 			memSize += int64(*entry.NrPages) * int64(pageSize)
 		}
 
+		shmemSize, err := memReader.GetShmemSize()
+		if err != nil {
+			return err
+		}
+
 		table.Append([]string{
 			fmt.Sprintf("%d", root.PID),
 			root.Comm,
 			metadata.ByteToString(memSize),
+			metadata.ByteToString(shmemSize),
 		})
 
 		for _, child := range root.Children {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230807192453-2210c022f3aa
+# github.com/checkpoint-restore/go-criu/v6 v6.3.1-0.20230822084504-f3c069bb94de
 ## explicit; go 1.18
 github.com/checkpoint-restore/go-criu/v6/crit
 github.com/checkpoint-restore/go-criu/v6/crit/images/bpfmap-data


### PR DESCRIPTION
This PR add a new column to the `memparse` table, which displays the shared memory size of each process within the checkpoint.

Example:

```bash

# checkpointctl memparse /tmp/mysql.tar.gz 

Displaying processes memory sizes from /tmp/checkpoints/mysql.tar.gz

+-----+--------------+-------------+--------------------+
| PID | PROCESS NAME | MEMORY SIZE | SHARED MEMORY SIZE |
+-----+--------------+-------------+--------------------+
|   1 | mysqld       | 349.7 MiB   | 188.0 KiB          |
+-----+--------------+-------------+--------------------+

```