### PR TITLE
tree: skip empty env variables branch

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -157,9 +157,11 @@ func addPsTreeToTree(tree treeprint.Tree, psTree *crit.PsTree, checkpointOutputD
 				return err
 			}
 
-			nodeSubtree := node.AddBranch("Environment variables")
-			for _, env := range envVars {
-				nodeSubtree.AddBranch(env)
+			if len(envVars) > 0 {
+				nodeSubtree := node.AddBranch("Environment variables")
+				for _, env := range envVars {
+					nodeSubtree.AddBranch(env)
+				}
 			}
 		}
 		for _, child := range root.Children {


### PR DESCRIPTION
In some cases, processes may remove all environment variables inherited from the parent process (e.g., [nginx](https://nginx.org/en/docs/ngx_core_module.html#env)). This pull request adds a conditional statement to show the environment variables tree branch only when necessary.