### PR TITLE
Handle time stamps from containerd checkpoint archives

### DIFF
--- a/internal/json.go
+++ b/internal/json.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/checkpoint-restore/go-criu/v7/crit"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -80,6 +81,7 @@ type DisplayNode struct {
 	ID                 string         `json:"id"`
 	Runtime            string         `json:"runtime"`
 	Created            string         `json:"created"`
+	Checkpointed       string         `json:"checkpointed,omitempty"`
 	Engine             string         `json:"engine"`
 	IP                 string         `json:"ip,omitempty"`
 	MAC                string         `json:"mac,omitempty"`
@@ -113,6 +115,10 @@ func RenderJSONView(tasks []Task) error {
 			Runtime:       info.configDump.OCIRuntime,
 			Created:       info.containerInfo.Created,
 			Engine:        info.containerInfo.Engine,
+		}
+
+		if !info.configDump.CheckpointedAt.IsZero() {
+			node.Checkpointed = info.configDump.CheckpointedAt.Format(time.RFC3339)
 		}
 
 		if info.containerInfo.IP != "" {

--- a/internal/tree.go
+++ b/internal/tree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/checkpoint-restore/go-criu/v7/crit"
@@ -89,6 +90,9 @@ func buildTree(ci *containerInfo, containerConfig *metadata.ContainerConfig, arc
 	tree.AddBranch(fmt.Sprintf("ID: %s", containerConfig.ID))
 	tree.AddBranch(fmt.Sprintf("Runtime: %s", containerConfig.OCIRuntime))
 	tree.AddBranch(fmt.Sprintf("Created: %s", ci.Created))
+	if !containerConfig.CheckpointedAt.IsZero() {
+		tree.AddBranch(fmt.Sprintf("Checkpointed: %s", containerConfig.CheckpointedAt.Format(time.RFC3339)))
+	}
 	tree.AddBranch(fmt.Sprintf("Engine: %s", ci.Engine))
 
 	if ci.IP != "" {

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -501,13 +501,14 @@ function teardown() {
 }
 
 @test "Run checkpointctl inspect with tar file with valid config.dump and valid spec.dump (CRI-O) and checkpoint directory" {
-	cp data/config.dump "$TEST_TMP_DIR1"
+	echo '{"checkpointedTime": "2024-02-09T11:01:26.186815191Z"}' > "$TEST_TMP_DIR1"/config.dump
 	cp data/spec.dump.cri-o "$TEST_TMP_DIR1"/spec.dump
 	mkdir "$TEST_TMP_DIR1"/checkpoint
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar
 	[ "$status" -eq 0 ]
-	[[ ${lines[6]} == *"CRI-O"* ]]
+	[[ ${lines[6]} == *"Checkpointed: 2024-02-09"* ]]
+	[[ ${lines[7]} == *"CRI-O"* ]]
 }
 
 @test "Run checkpointctl inspect with tar file and rootfs-diff tar file" {


### PR DESCRIPTION
This fixes containerd archive created time handling and adds checkpointed time for all archives.