### PR TITLE
Add support to convert checkpoint archives to OCI images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install tools
         run: |
-          sudo dnf -y install ShellCheck bats golang criu asciidoctor iptables iproute kmod jq bash bash-completion zsh fish
+          sudo dnf -y install ShellCheck shfmt bats golang criu asciidoctor iptables iproute kmod jq bash bash-completion zsh fish
           sudo modprobe -va ip_tables ip6table_filter nf_conntrack nf_conntrack_netlink
+      - name: Run make shfmt-lint
+        run: make shfmt-lint
       - name: Run make shellcheck
         run: make shellcheck
       - name: Run make all

--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -31,6 +31,8 @@ func main() {
 
 	rootCommand.AddCommand(cmd.List())
 
+	rootCommand.AddCommand(cmd.BuildCmd())
+
 	rootCommand.Version = version
 
 	if err := rootCommand.Execute(); err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/checkpoint-restore/checkpointctl/internal"
+	"github.com/spf13/cobra"
+)
+
+func BuildCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "build [checkpoint-path] [image-name]",
+		Short: "Create an OCI image from a container checkpoint archive",
+		RunE:  convertArchive,
+	}
+
+	return cmd
+}
+
+func convertArchive(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("please provide both the checkpoint path and the image name")
+	}
+
+	checkpointPath := args[0]
+	imageName := args[1]
+
+	imageCreater := internal.NewImageCreator(imageName, checkpointPath)
+
+	err := imageCreater.CreateImageFromCheckpoint(context.Background())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Image '%s' created successfully from checkpoint '%s'\n", imageName, checkpointPath)
+	return nil
+}

--- a/docs/checkpointctl-build.adoc
+++ b/docs/checkpointctl-build.adoc
@@ -1,0 +1,25 @@
+= checkpointctl-build(1)
+include::footer.adoc[]
+
+== Name
+
+*checkpointctl-build* - Create OCI image from a checkpoint tar file.
+
+== Synopsis
+
+*checkpointctl build* CHECKPOINT_PATH IMAGE_NAME 
+
+== Options
+
+*-h*, *--help*::
+  Show help for checkpointctl build
+
+== Description
+
+Creates an OCI image from a checkpoint tar file. This command requires `buildah` to be installed on the system.
+
+Please ensure that `buildah` is installed before running this command.
+
+== See also
+
+checkpointctl(1)

--- a/internal/image_from_checkpoint_archive.go
+++ b/internal/image_from_checkpoint_archive.go
@@ -1,0 +1,113 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	metadata "github.com/checkpoint-restore/checkpointctl/lib"
+)
+
+const (
+	BUILD_SCRIPT  = "/usr/libexec/build_image.sh"
+	PODMAN_ENGINE = "libpod"
+)
+
+type ImageCreator struct {
+	imageName      string
+	checkpointPath string
+}
+
+func NewImageCreator(imageName, checkpointPath string) *ImageCreator {
+	return &ImageCreator{
+		imageName:      imageName,
+		checkpointPath: checkpointPath,
+	}
+}
+
+func (ic *ImageCreator) CreateImageFromCheckpoint(ctx context.Context) error {
+	tempDir, err := os.MkdirTemp("", "checkpoint_tmp")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	annotationsFilePath, err := ic.setCheckpointAnnotations(tempDir)
+	if err != nil {
+		return err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Command(BUILD_SCRIPT, "-a", annotationsFilePath, "-c", ic.checkpointPath, "-i", ic.imageName)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to execute script: %v, %v, %w", stdout.String(), stderr.String(), err)
+	}
+
+	return nil
+}
+
+func writeAnnotationsToFile(tempDir string, annotations map[string]string) (string, error) {
+	tempFile, err := os.CreateTemp(tempDir, "annotations_*.txt")
+	if err != nil {
+		return "", err
+	}
+	defer tempFile.Close()
+
+	for key, value := range annotations {
+		_, err := fmt.Fprintf(tempFile, "%s=%s\n", key, value)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return tempFile.Name(), nil
+}
+
+func (ic *ImageCreator) setCheckpointAnnotations(tempDir string) (string, error) {
+	filesToExtract := []string{"spec.dump", "config.dump"}
+	if err := UntarFiles(ic.checkpointPath, tempDir, filesToExtract); err != nil {
+		log.Printf("Error extracting files from archive %s: %v\n", ic.checkpointPath, err)
+		return "", err
+	}
+
+	var err error
+	info := &checkpointInfo{}
+	info.configDump, _, err = metadata.ReadContainerCheckpointConfigDump(tempDir)
+	if err != nil {
+		return "", err
+	}
+
+	info.specDump, _, err = metadata.ReadContainerCheckpointSpecDump(tempDir)
+	if err != nil {
+		return "", err
+	}
+
+	info.containerInfo, err = getContainerInfo(info.specDump, info.configDump)
+	if err != nil {
+		return "", err
+	}
+
+	checkpointImageAnnotations := map[string]string{}
+	checkpointImageAnnotations[metadata.CheckpointAnnotationEngine] = info.containerInfo.Engine
+	checkpointImageAnnotations[metadata.CheckpointAnnotationName] = info.containerInfo.Name
+	checkpointImageAnnotations[metadata.CheckpointAnnotationPod] = info.containerInfo.Pod
+	checkpointImageAnnotations[metadata.CheckpointAnnotationNamespace] = info.containerInfo.Namespace
+	checkpointImageAnnotations[metadata.CheckpointAnnotationRootfsImageUserRequested] = info.configDump.RootfsImage
+	checkpointImageAnnotations[metadata.CheckpointAnnotationRootfsImageName] = info.configDump.RootfsImageName
+	checkpointImageAnnotations[metadata.CheckpointAnnotationRootfsImageID] = info.configDump.RootfsImageRef
+	checkpointImageAnnotations[metadata.CheckpointAnnotationRuntimeName] = info.configDump.OCIRuntime
+
+	annotationsFilePath, err := writeAnnotationsToFile(tempDir, checkpointImageAnnotations)
+	if err != nil {
+		return "", err
+	}
+
+	return annotationsFilePath, nil
+}

--- a/internal/scripts/build_image.sh
+++ b/internal/scripts/build_image.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+	cat <<EOF
+Usage: ${0##*/} [-a ANNOTATIONS_FILE] [-c CHECKPOINT_PATH] [-i IMAGE_NAME]
+Create OCI image from a checkpoint tar file.
+
+    -a          path to the annotations file
+    -c          path to the checkpoint file
+    -i          name of the resulting image
+EOF
+	exit 1
+}
+
+annotationsFilePath=""
+checkpointPath=""
+imageName=""
+
+while getopts ":a:c:i:" opt; do
+	case ${opt} in
+	a)
+		annotationsFilePath=$OPTARG
+		;;
+	c)
+		checkpointPath=$OPTARG
+		;;
+	i)
+		imageName=$OPTARG
+		;;
+	:)
+		echo "Option -$OPTARG requires an argument."
+		usage
+		;;
+	\?)
+		echo "Invalid option: -$OPTARG"
+		usage
+		;;
+	esac
+done
+shift $((OPTIND - 1))
+
+if [[ -z $annotationsFilePath || -z $checkpointPath || -z $imageName ]]; then
+	echo "All options (-a, -c, -i) are required."
+	usage
+fi
+
+if ! command -v buildah &>/dev/null; then
+	echo "buildah is not installed. Please install buildah before running 'checkpointctl build' command."
+	exit 1
+fi
+
+if [[ ! -f $annotationsFilePath ]]; then
+	echo "Annotations file not found: $annotationsFilePath"
+	exit 1
+fi
+
+if [[ ! -f $checkpointPath ]]; then
+	echo "Checkpoint file not found: $checkpointPath"
+	exit 1
+fi
+
+newcontainer=$(buildah from scratch)
+
+buildah add "$newcontainer" "$checkpointPath"
+
+while IFS= read -r line; do
+	key=$(echo "$line" | cut -d '=' -f 1)
+	value=$(echo "$line" | cut -d '=' -f 2-)
+	buildah config --annotation "$key=$value" "$newcontainer"
+done <"$annotationsFilePath"
+
+buildah commit "$newcontainer" "$imageName"
+
+buildah rm "$newcontainer"
+
+echo "Checkpoint image created successfully: $imageName"


### PR DESCRIPTION
Resolves: #52 

This PR introduce a new command `checkpointctl build`, which can be used to convert checkpoint archives to OCI images. The command accepts a checkpoint archive and a image name as input and generates an OCI image suitable for use with container runtimes like CRI-O or Podman.

```
➜  ~ checkpointctl build /var/lib/kubelet/checkpoints/checkpoint-nginx-deployment-85bfd45d84-kfxmm_default-nginx-2024-03-29T11:32:17+05:30.tar test-checkpointctl:v1 

2024/04/03 19:05:26 Created checkpoint image: 7b3135033935815023dcdc810419ee1894621436b4d7622440691e4197db451c
2024/04/03 19:05:26 Image 'test-checkpointctl:v1' created successfully from checkpoint '/var/lib/kubelet/checkpoints/checkpoint-nginx-deployment-85bfd45d84-kfxmm_default-nginx-2024-03-29T11:32:17+05:30.tar'
```
```
➜  ~ podman images
REPOSITORY                                 TAG              IMAGE ID      CREATED         SIZE
docker.io/library/test-checkpointctl       v1               7b3135033935  33 seconds ago  15.8 MB

```

we can inspect the image using podman - 
```
➜  ~  podman image inspect 7b3135033935                           
[
     {
          "Id": "7b3135033935815023dcdc810419ee1894621436b4d7622440691e4197db451c",
          "Digest": "sha256:08ee0bc5036915f52b4a2d7a1a9746302cd4010322ef609b121407589b476078",
          "RepoTags": [
               "docker.io/library/test-checkpointctl:v1"
          ],
          "RepoDigests": [
               "docker.io/library/test-checkpointctl@sha256:08ee0bc5036915f52b4a2d7a1a9746302cd4010322ef609b121407589b476078"
          ],
          "Parent": "",
          "Comment": "",
          "Created": "2024-04-03T13:35:26.175477795Z",
          "Config": {},
          "Version": "",
          "Author": "",
          "Architecture": "amd64",
          "Os": "linux",
          "Size": 15841874,
          "VirtualSize": 15841874,
          "GraphDriver": {
               "Name": "overlay",
               "Data": {
                    "UpperDir": "/var/lib/containers/storage/overlay/fc8fdb8e1d92bfb6fd9d5e448a90993389fc3837f5ba3e226602d3c7b6de2e71/diff",
                    "WorkDir": "/var/lib/containers/storage/overlay/fc8fdb8e1d92bfb6fd9d5e448a90993389fc3837f5ba3e226602d3c7b6de2e71/work"
               }
          },
          "RootFS": {
               "Type": "layers",
               "Layers": [
                    "sha256:fc8fdb8e1d92bfb6fd9d5e448a90993389fc3837f5ba3e226602d3c7b6de2e71"
               ]
          },
          "Labels": null,
          "Annotations": {
               "io.container.manager": "CRI-O",
               "io.kubernetes.cri-o.annotations.checkpoint.name": "nginx",
               "io.kubernetes.cri-o.annotations.checkpoint.namespace": "default",
               "io.kubernetes.cri-o.annotations.checkpoint.pod": "nginx-deployment-85bfd45d84-kfxmm",
               "io.kubernetes.cri-o.annotations.checkpoint.rootfsImage": "docker.io/library/nginx@sha256:52478f8cd6a142fd462f0a7614a7bb064e969a4c083648235d6943c786df8cc7",
               "io.kubernetes.cri-o.annotations.checkpoint.rootfsImageID": "92b11f67642b62bbb98e7e49169c346b30e20cd3c1c034d31087e46924b9312e",
               "io.kubernetes.cri-o.annotations.checkpoint.rootfsImageName": "docker.io/library/nginx:latest",
               "io.kubernetes.cri-o.annotations.checkpoint.runtime.name": "runc",
               "org.opencontainers.image.base.digest": "",
               "org.opencontainers.image.base.name": ""
          },
          "ManifestType": "application/vnd.oci.image.manifest.v1+json",
          "User": "",
          "History": [
               {
                    "created": "2024-04-03T13:35:26.253908385Z",
                    "created_by": "/bin/sh"
               }
          ],
          "NamesHistory": [
               "docker.io/library/test-checkpointctl:v1"
          ]
     }
]

```