### PR TITLE
Additional container metadata from containerd

### DIFF
--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -16,6 +16,7 @@ const (
 	// container archive
 	ConfigDumpFile             = "config.dump"
 	SpecDumpFile               = "spec.dump"
+	StatusDumpFile             = "status.dump"
 	NetworkStatusFile          = "network.status"
 	CheckpointDirectory        = "checkpoint"
 	CheckpointVolumesDirectory = "volumes"


### PR DESCRIPTION
containerd structures the internal metadata differently. For a restore the status.dump file is also necessary.