### PR TITLE
Add maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,4 @@
+Adrian Reber <areber@redhat.com>
+Behouba Manassé Kouamé <behouba@gmail.com>
+Prajwal S N <prajwalnadig21@gmail.com>
+Radostin Stoyanov <rstoyanov@fedoraproject.org>


### PR DESCRIPTION
This pull request adds a MAINTAINERS file that contains a canonical list of maintainers for this repository. For more information on the role and responsibilities of a maintainer, please refer to the [maintainers guide](https://github.com/checkpoint-restore/criu/blob/criu-dev/MAINTAINERS_GUIDE.md) available in the CRIU repository.