### PR TITLE
ci: use codecov-action to upload coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   coverage:
+    if: ${{ github.repository == 'checkpoint-restore/checkpointctl' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # needed for codecov
           fetch-depth: 0
@@ -20,5 +21,11 @@ jobs:
           sudo apt-get install -qqy criu
       - name: Run make coverage
         run: sudo -E make coverage
-      - name: Run make codecov
-        run: make codecov
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          file: .coverage/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,6 @@ coverage: $(NAME).coverage
 	$(GO) tool covdata percent -i=${COVERAGE_PATH}
 	$(GO) tool covdata textfmt -i=${COVERAGE_PATH} -o ${COVERAGE_PATH}/coverage.out
 
-.PHONY: codecov
-codecov:
-	curl -Os https://uploader.codecov.io/latest/linux/codecov
-	chmod +x codecov
-	./codecov -f "$(COVERAGE_PATH)"/coverage.out
-
 .PHONY: vendor
 vendor:
 	go mod tidy
@@ -139,7 +133,6 @@ help:
 	@echo " * test - run tests"
 	@echo " * test-junit - run tests and create junit output"
 	@echo " * coverage - generate test coverage report"
-	@echo " * codecov - upload coverage report to codecov.io"
 	@echo " * install - install the binary to $(BINDIR)"
 	@echo " * uninstall - remove the installed binary from $(BINDIR)"
 	@echo " * release - build a static binary"


### PR DESCRIPTION
Uploading code coverage currently fails with the following error:

```
Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.
```

This pull request replaces the `codecov` Makefile target with [codecov-action](https://github.com/codecov/codecov-action) to fix this problem.