### PR TITLE
Fix location of Open Files in tree

### DIFF
--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -359,7 +359,7 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --files
 	[ "$status" -eq 0 ]
-	[[ ${lines[24]} == *"[REG 0]"* ]]
+	[[ ${lines[11]} == *"[REG 0]"* ]]
 	[[ ${lines[25]} == *"[cwd]"* ]]
 	[[ ${lines[26]} == *"[root]"* ]]
 }

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -20,9 +20,8 @@ function setup() {
 }
 
 function teardown() {
-	#[ "$TEST_TMP_DIR1" != "" ] && rm -rf "$TEST_TMP_DIR1"
-	#[ "$TEST_TMP_DIR2" != "" ] && rm -rf "$TEST_TMP_DIR2"
-	echo hu
+	[ "$TEST_TMP_DIR1" != "" ] && rm -rf "$TEST_TMP_DIR1"
+	[ "$TEST_TMP_DIR2" != "" ] && rm -rf "$TEST_TMP_DIR2"
 }
 
 @test "Run checkpointctl" {


### PR DESCRIPTION
Without this patch the output used to look something like this
```
│   └── [1]  bash
│       ├── Environment variables
│       ├── [8]  /usr/bin/coreutils
│       │   ├── Environment variables
│       │   └── Open files
│       │       └── [root]  /
│       ├── [7]  /usr/bin/python3
│       │   ├── Environment variables
│       │   ├── Open files
│       │   │   └── [root]  /
│       │   └── Open sockets
│       │       └── [TCP (LISTEN)]  0.0.0.0:8088 -> 0.0.0.0:0 (↑ 16.0 KB ↓ 128.0 KB)
│       └── Open files
│           └── [root]  /
```
Which is wrong as the list of open files (and sockets) for the first
process is after the child processes. With this change the order is now
correct:
```
│   └── [1]  bash
│       ├── Environment variables
│       ├── Open files
│       │   └── [root]  /
│       ├── [7]  /usr/bin/python3
│       │   ├── Environment variables
│       │   ├── Open files
│       │   │   └── [root]  /
│       │   └── Open sockets
│       │       └── [TCP (LISTEN)]  0.0.0.0:8088 -> 0.0.0.0:0 (↑ 16.0 KB ↓ 128.0 KB)
│       └── [8]  /usr/bin/coreutils
│           ├── Environment variables
│           └── Open files
│               └── [root]  /
```
Each process has its own "Open files" and "Open sockets". It was always
correct for "Environment variables".