### PR TITLE
Upgrade more GitHub Actions versions to remove deprecation warnings

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v6
       with:
         version: latest
         only-new-issues: true
@@ -32,7 +32,7 @@ jobs:
       pull-requests: read
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: changes
       with:
         filters: |
@@ -41,7 +41,7 @@ jobs:
             - '.github/workflows/verify.yml'
     - name: Lint markdown
       if: steps.changes.outputs.md == 'true'
-      uses: DavidAnson/markdownlint-cli2-action@v10
+      uses: DavidAnson/markdownlint-cli2-action@v17
       with:
         globs: |
           README.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable MD041 -->
-<p1 align="center"><img src="docs/checkpointctl.svg" height="250"></p>
+<p1 align="center">
+    <img src="docs/checkpointctl.svg" height="250" alt="checkpointctl logo">
+</p>
 
 <!-- markdownlint-disable MD013 -->
 # checkpointctl - a tool for in-depth analysis of container checkpoints


### PR DESCRIPTION
In the previous PR I missed three actions upgrades.