### PR TITLE
Add option to print metadata information

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ checkpointctl show /var/lib/kubelet/checkpoints/checkpoint-counters_default-co
 To retrieve low-level information about a container checkpoint, use the `checkpointctl inspect` command:
 
 ```console
-$ checkpointctl inspect /tmp/ubuntu_looper.tar.gz --ps-tree
+$ checkpointctl inspect /tmp/ubuntu_looper.tar.gz --ps-tree --metadata
 
 awesome_booth
 ├── Image: docker.io/library/ubuntu:latest
@@ -65,6 +65,10 @@ awesome_booth
 ├── Engine: Podman
 ├── Checkpoint size: 2.8 MiB
 ├── Root FS diff size: 309.0 KiB
+├── Metadata
+│   └── Annotations
+│       ├── io.container.manager: libpod
+│       └── org.opencontainers.image.stopSignal: 15
 └── Process tree
     └── [1]  bash
         └── [5]  su

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -79,6 +79,12 @@ func Inspect() *cobra.Command {
 		"tree",
 		"Specify the output format: tree or json",
 	)
+	flags.BoolVar(
+		showMetdata,
+		"metadata",
+		false,
+		"Show metadata about the container",
+	)
 
 	return cmd
 }
@@ -91,6 +97,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 		*psTreeEnv = true
 		*files = true
 		*sockets = true
+		*showMetdata = true
 	}
 
 	requiredFiles := []string{metadata.SpecDumpFile, metadata.ConfigDumpFile}

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -17,4 +17,5 @@ var (
 	searchPattern      *string = &internal.SearchPattern
 	searchRegexPattern *string = &internal.SearchRegexPattern
 	searchContext      *int    = &internal.SearchContext
+	showMetdata        *bool   = &internal.Metadata
 )

--- a/internal/options.go
+++ b/internal/options.go
@@ -15,4 +15,5 @@ var (
 	SearchPattern      string
 	SearchRegexPattern string
 	SearchContext      int
+	Metadata           bool
 )

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -449,13 +449,14 @@ function teardown() {
 	[[ ${lines[9]} == *"CRIU dump statistics"* ]]
 	[[ ${lines[13]} == *"Memwrite time"* ]]
 	[[ ${lines[14]} =~ [1-9] ]]
-	[[ ${lines[16]} == *"Process tree"* ]]
-	[[ ${lines[17]} == *"piggie"* ]]
 
 	expected_messages=(
 		"[REG 0]"
 		"[cwd]"
 		"[root]"
+		"Metadata"
+		"Process tree"
+		"piggie"
 		"Overview of mounts"
 		"Destination"
 		"proc"


### PR DESCRIPTION
This adds an option to print out container metadata. In the case of CRI-O this can look like:
```
├── Metadata
│   ├── Name: counters
│   ├── Namespace: default
│   └── Annotations
│       ├── io.kubernetes.cri-o.ImageName: quay.io/adrianreber/counter:latest
```
Currently this contains all annotations from the container.