### PR TITLE
Create directories with 700 and not 644

### DIFF
--- a/internal/container.go
+++ b/internal/container.go
@@ -244,7 +244,7 @@ func UntarFiles(src, dest string, files []string) error {
 		for _, file := range files {
 			if strings.Contains(header.Name, file) {
 				// Create the destination folder
-				if err := os.MkdirAll(filepath.Join(dest, filepath.Dir(header.Name)), 0o644); err != nil {
+				if err := os.MkdirAll(filepath.Join(dest, filepath.Dir(header.Name)), 0o700); err != nil {
 					return err
 				}
 				// Create the destination file


### PR DESCRIPTION
checkpointctl was creating directories with 644 which broke usage when running as non-root as checkpointctl was not able to access the directories it created itself. Switching to 700 fixes it.

This comes with a test to verify that checkpointctl works as non-root.

Fixes: #153