### PR TITLE
fix(ci): move from Fedora to Ubuntu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,14 +5,18 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:latest
-      options: --privileged --cap-add=NET_ADMIN --cap-add=NET_RAW -v /lib/modules:/lib/modules
     steps:
       - uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          check-latest: true
       - name: Install tools
         run: |
-          sudo dnf -y install ShellCheck bats golang criu asciidoctor iptables iproute kmod jq bash bash-completion zsh fish
+          # Add PPA for CRIU
+          sudo add-apt-repository ppa:criu/ppa
+          sudo apt-get update
+          sudo apt-get install -qqy shellcheck bats criu asciidoctor iptables iproute2 kmod jq bash bash-completion zsh fish
           sudo modprobe -va ip_tables ip6table_filter nf_conntrack nf_conntrack_netlink
       - name: Run make shellcheck
         run: make shellcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 ---
 run:
   concurrency: 6
-  deadline: 5m
+  timeout: 5m
 linters:
   enable:
     - errorlint


### PR DESCRIPTION
Previously, we were using Fedora as Ubuntu did not contain the updated
binaries for bats. CRIU was also outdated on the main repositories.
Due to a recent change in the way GitHub runners handle privileged
containers, the old Fedora setup no longer works. This is the easiest
solution that allows us to retain sudo-based local tests that can also
be reused on CI.