### PR TITLE
Display network information of checkpoints created with Podman

### DIFF
--- a/internal/config_extractor.go
+++ b/internal/config_extractor.go
@@ -39,7 +39,11 @@ func ExtractConfigDump(checkpointPath string) (*ChkptConfig, error) {
 		return nil, err
 	}
 
-	info.containerInfo, err = getContainerInfo(info.specDump, info.configDump)
+	task := Task{
+		OutputDir:          tempDir,
+		CheckpointFilePath: checkpointPath,
+	}
+	info.containerInfo, err = getContainerInfo(info.specDump, info.configDump, task)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oci_image_build.go
+++ b/internal/oci_image_build.go
@@ -116,7 +116,11 @@ func (ic *ImageBuilder) getCheckpointAnnotations() (map[string]string, error) {
 		return nil, err
 	}
 
-	info.containerInfo, err = getContainerInfo(info.specDump, info.configDump)
+	task := Task{
+		OutputDir:          tempDir,
+		CheckpointFilePath: ic.checkpointPath,
+	}
+	info.containerInfo, err = getContainerInfo(info.specDump, info.configDump, task)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/podman_network.go
+++ b/internal/podman_network.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// PodmanNetworkStatus represents the network status structure for Podman
+type PodmanNetworkStatus struct {
+	Podman struct {
+		Interfaces map[string]struct {
+			Subnets []struct {
+				IPNet   string `json:"ipnet"`
+				Gateway string `json:"gateway"`
+			} `json:"subnets"`
+			MacAddress string `json:"mac_address"`
+		} `json:"interfaces"`
+	} `json:"podman"`
+}
+
+// getPodmanNetworkInfo reads and parses the network.status file from a Podman checkpoint
+func getPodmanNetworkInfo(networkStatusFile string) (string, string, error) {
+	data, err := os.ReadFile(networkStatusFile)
+	if err != nil {
+		// Return empty strings if file doesn't exist or can't be read
+		// This maintains compatibility with containers that don't have network info
+		return "", "", nil
+	}
+
+	var status PodmanNetworkStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return "", "", fmt.Errorf("failed to parse network status: %w", err)
+	}
+
+	// Get the first interface's information
+	// Most containers will have a single interface (eth0)
+	for _, info := range status.Podman.Interfaces {
+		if len(info.Subnets) > 0 {
+			return info.Subnets[0].IPNet, info.MacAddress, nil
+		}
+	}
+
+	return "", "", nil
+}

--- a/internal/podman_network_test.go
+++ b/internal/podman_network_test.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	metadata "github.com/checkpoint-restore/checkpointctl/lib"
+)
+
+func TestGetPodmanNetworkInfo(t *testing.T) {
+	// Test case 1: Valid network status file
+	networkStatus := `{
+		"podman": {
+			"interfaces": {
+				"eth0": {
+					"subnets": [
+						{
+							"ipnet": "10.88.0.9/16",
+							"gateway": "10.88.0.1"
+						}
+					],
+					"mac_address": "f2:99:8d:fb:5a:57"
+				}
+			}
+		}
+	}`
+
+	networkStatusFile := filepath.Join(t.TempDir(), metadata.NetworkStatusFile)
+	if err := os.WriteFile(networkStatusFile, []byte(networkStatus), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	ip, mac, err := getPodmanNetworkInfo(networkStatusFile)
+	if err != nil {
+		t.Errorf("getPodmanNetworkInfo failed: %v", err)
+	}
+
+	expectedIP := "10.88.0.9/16"
+	expectedMAC := "f2:99:8d:fb:5a:57"
+
+	if ip != expectedIP {
+		t.Errorf("Expected IP %s, got %s", expectedIP, ip)
+	}
+	if mac != expectedMAC {
+		t.Errorf("Expected MAC %s, got %s", expectedMAC, mac)
+	}
+
+	// Test case 2: Missing network status file
+	nonExistentFile := filepath.Join(t.TempDir(), metadata.NetworkStatusFile)
+	ip, mac, err = getPodmanNetworkInfo(nonExistentFile)
+	if err != nil {
+		t.Errorf("getPodmanNetworkInfo with missing file should not return error, got: %v", err)
+	}
+	if ip != "" || mac != "" {
+		t.Errorf("Expected empty IP and MAC for missing file, got IP=%s, MAC=%s", ip, mac)
+	}
+
+	// Test case 3: Invalid JSON
+	invalidJSONFile := filepath.Join(t.TempDir(), metadata.NetworkStatusFile)
+	if err := os.WriteFile(invalidJSONFile, []byte("invalid json"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	ip, mac, err = getPodmanNetworkInfo(invalidJSONFile)
+	if err == nil {
+		t.Error("getPodmanNetworkInfo should fail with invalid JSON")
+	}
+}


### PR DESCRIPTION
This PR implements support for displaying network information (IP and MAC addresses) from Podman container checkpoints, addressing issue.

Currently, checkpointctl shows IP address information for checkpoints created with CRI-O but not with Podman. For Podman checkpoints, this information is stored in network.status in JSON format.

Implementation:
- Added network.status file parsing functionality
- Added IP and MAC address display to checkpoint show output
- Added test coverage for network information parsing

Testing Results:
Before (Original Output) and After (With Network Information output)

![Screenshot (1191)](https://github.com/user-attachments/assets/b628220b-dc06-4baf-8b04-aea032aee9e1)

![Screenshot (1195)](https://github.com/user-attachments/assets/83d32e09-6441-4386-ada6-1aeceac4bf67)


The implementation successfully displays:
- Container's IP address
- MAC address
- Maintains existing checkpoint information

Fixes #132
