### PR TITLE
workflows: add explicit permissions to fix CodeQL warnings

### DIFF
--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   check_size:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,9 @@ name: Run coverage
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,6 +2,9 @@ name: verify
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add explicit permissions blocks to GitHub Actions workflows that were missing them. This fixes CodeQL warnings about workflows not containing permissions declarations.

All workflows now specify 'contents: read' at the top level, following the principle of least privilege. Jobs that require additional permissions can still override at the job level.

Workflows updated:
- check-size.yml
- coverage.yml
- tests.yml
- verify.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)