### PR TITLE
go.mod: bump minimum Go version to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/checkpoint-restore/checkpointctl
 
-go 1.23.0
-
-toolchain go1.24.2
+go 1.24.6
 
 require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0


### PR DESCRIPTION
Increase the minimum required Go version from 1.23.0 to 1.24.6 to address CVE-2025-47906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)