### PR TITLE
workflows: add PR comment on binary size check failure

### DIFF
--- a/.github/workflows/check-size-comment.yml
+++ b/.github/workflows/check-size-comment.yml
@@ -1,0 +1,95 @@
+name: Check binary size comment
+
+on:
+  workflow_run:
+    workflows: [Check binary size]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: Post Size Check Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+
+    steps:
+    - name: Download artifacts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        mkdir -p artifacts && cd artifacts
+
+        artifacts_url="${{ github.event.workflow_run.artifacts_url }}"
+
+        gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+        do
+          IFS=$'\t' read name url <<< "$artifact"
+          if [ "$name" != "size-check-results" ]; then
+            continue
+          fi
+          gh api $url > "$name.zip"
+          unzip -d "$name" "$name.zip"
+        done
+
+    - name: Check for artifacts
+      id: artifact_check
+      run: |
+        if [ -e artifacts/size-check-results/event.json ] && [ -e artifacts/size-check-results/comment.md ]; then
+          echo "artifacts_found=true" >> $GITHUB_OUTPUT
+        else
+          echo "artifacts_found=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Post comment to PR
+      if: steps.artifact_check.outputs.artifacts_found == 'true'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+
+          const event = JSON.parse(fs.readFileSync('artifacts/size-check-results/event.json', 'utf8'));
+          const commentBody = fs.readFileSync('artifacts/size-check-results/comment.md', 'utf8');
+
+          if (!event.pull_request) {
+            console.log('Not a pull request event, skipping comment');
+            return;
+          }
+
+          const { owner, repo } = context.repo;
+          const prNumber = event.pull_request.number;
+
+          console.log(`Posting comment to PR #${prNumber}`);
+
+          const comments = await github.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number: prNumber,
+          });
+
+          const existingComment = comments.data.find(comment =>
+            comment.body.includes('## Binary Size Check Failed') &&
+            comment.user.type === 'Bot'
+          );
+
+          if (existingComment) {
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: existingComment.id,
+              body: commentBody
+            });
+            console.log(`Updated existing comment ${existingComment.id}`);
+          } else {
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: commentBody
+            });
+            console.log('Created new comment');
+          }

--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -25,6 +25,50 @@ jobs:
         git config --global user.name "checkpoint-restore"
     - name: Configure base branch without switching current branch
       run: git fetch origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}
+    - name: Save PR context
+      env:
+        EVENT_JSON: ${{ toJSON(github.event) }}
+      run: |
+        mkdir -p artifacts
+        printenv EVENT_JSON > artifacts/event.json
     - name: Compare binary size change across each commit
+      id: size-check
       # Use the last non-merge commit from the base branch as the baseline
-      run: git rebase -v $(git rev-list --no-merges -n 1 ${GITHUB_BASE_REF})^ -x test/check-size.sh
+      run: |
+        set +e
+        OUTPUT=$(git rebase -v $(git rev-list --no-merges -n 1 ${GITHUB_BASE_REF})^ -x test/check-size.sh 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        echo "$OUTPUT" > artifacts/output.txt
+        echo "exit_code=${EXIT_CODE}" >> $GITHUB_OUTPUT
+        exit $EXIT_CODE
+    - name: Generate size check comment
+      if: failure()
+      run: |
+        cat > artifacts/comment.md << 'EOF'
+        ## Binary Size Check Failed
+
+        The binary size increase exceeds the allowed threshold.
+
+        ### Size Check Output
+        ```
+        EOF
+        cat artifacts/output.txt >> artifacts/comment.md
+        cat >> artifacts/comment.md << 'EOF'
+        ```
+
+        ### How to resolve
+
+        If this size increase is expected and acceptable, a maintainer can add
+        the `bloat-ok` label to this PR to bypass the size check.
+
+        ---
+        *Binary size check performed by CI*
+        EOF
+    - name: Upload size check results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: size-check-results
+        retention-days: 5
+        path: artifacts/

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ PRs that fix issues should include a reference like `Closes #XXXX` in the
 commit message so that github will automatically close the referenced issue
 when the PR is merged.
 
+PRs are checked for binary size increases. If a PR legitimately increases
+the binary size beyond the default threshold, a maintainer can add the
+`bloat-ok` label to bypass the size check.
+
 Contributors must assert that they are in compliance with the [Developer
 Certificate of Origin 1.1](http://developercertificate.org/). This is achieved
 by adding a "Signed-off-by" line containing the contributor's name and e-mail


### PR DESCRIPTION
Document the existing bloat-ok label functionality in README.md for bypassing the binary size check. Add support for posting a PR comment when the size check fails, which helps contributors from forks understand why the check failed and how to resolve it. This uses a two-workflow approach: the main workflow uploads artifacts, and a separate workflow triggered by workflow_run posts the comment with proper permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)