### PR TITLE
docs: document asciidoctor and Go version requirements and ignore install artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,14 +191,16 @@ then uploads the newly created OCI image to the container registry, making it av
     On Fedora, CentOS and related distributions:
 
     ```console
-    sudo yum install -y go make
+    sudo yum install -y make asciidoctor
     ```
 
     On Debian, Ubuntu, and related distributions:
 
     ```console
-    sudo apt-get install -y golang make
+    sudo apt-get install -y make asciidoctor
     ```
+
+    Linux distributions often provide an old version of the golang compiler. We recommend to install Go from the [official tarballs](https://go.dev/doc/install).
 
 3. Build.
 


### PR DESCRIPTION
 This PR makes two small but important updates:

* **README** 
  * Added **asciidoctor** to the list of required packages. Without it, make install fails during documentation generation.
  * docs: documented Go version issues

* **.gitignore** – Added the `install/` folder to prevent generated files (e.g., completions) from being tracked by Git.

These changes improve the build/install process and keep the repository clean from artifacts.