### PR TITLE
Upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,28 @@
----
+version: "2"
 run:
   concurrency: 6
-  timeout: 5m
 linters:
   enable:
     - errorlint
     - unconvert
-    - gofumpt
     - unparam
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Modify golangci lint config with breaking changes from v1 to v2.

Done using `golangci-lint migrate` tool following https://golangci-lint.run/docs/product/migration-guide/