### PR TITLE
Add support for parsing of TaskState

### DIFF
--- a/internal/json.go
+++ b/internal/json.go
@@ -28,11 +28,12 @@ type StatsNode struct {
 }
 
 type PsNode struct {
-	PID      uint32            `json:"pid"`
-	Comm     string            `json:"command"`
-	Cmdline  string            `json:"cmdline,omitempty"`
-	EnvVars  map[string]string `json:"environment_variables,omitempty"`
-	Children []PsNode          `json:"children,omitempty"`
+	PID       uint32            `json:"pid"`
+	Comm      string            `json:"command"`
+	Cmdline   string            `json:"cmdline,omitempty"`
+	TaskState string            `json:"task_state,omitempty"`
+	EnvVars   map[string]string `json:"environment_variables,omitempty"`
+	Children  []PsNode          `json:"children,omitempty"`
 }
 
 type FdNode struct {
@@ -254,9 +255,15 @@ func buildJSONPsTree(psTree *crit.PsTree, checkpointOutputDir string) (PsNode, e
 }
 
 func buildJSONPsNode(psTree *crit.PsTree, checkpointOutputDir string) (PsNode, error) {
+	taskState := crit.TaskState(psTree.Core.GetTc().GetTaskState())
 	node := PsNode{
-		PID:  psTree.PID,
-		Comm: psTree.Comm,
+		PID:       psTree.PID,
+		Comm:      psTree.Comm,
+		TaskState: taskState.String(),
+	}
+
+	if !taskState.IsAliveOrStopped() {
+		return node, nil
 	}
 
 	if PsTreeCmd {

--- a/internal/json_test.go
+++ b/internal/json_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/checkpoint-restore/go-criu/v8/crit"
+	criu_core "github.com/checkpoint-restore/go-criu/v8/crit/images/criu-core"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -112,21 +113,25 @@ func TestBuildJSONMounts(t *testing.T) {
 }
 
 func TestBuildJSONPsTree(t *testing.T) {
+	aliveState := uint32(1) // COMPEL_TASK_ALIVE
+	coreEntry := &criu_core.CoreEntry{Tc: &criu_core.TaskCoreEntry{TaskState: &aliveState}}
 	psTree := &crit.PsTree{
 		PID:  1,
 		Comm: "root",
+		Core: coreEntry,
 		Children: []*crit.PsTree{
-			{PID: 2, Comm: "child1"},
-			{PID: 3, Comm: "child2"},
+			{PID: 2, Comm: "child1", Core: coreEntry},
+			{PID: 3, Comm: "child2", Core: coreEntry},
 		},
 	}
 
 	expectedPsTree := PsNode{
-		PID:  1,
-		Comm: "root",
+		PID:       1,
+		Comm:      "root",
+		TaskState: "Alive",
 		Children: []PsNode{
-			{PID: 2, Comm: "child1"},
-			{PID: 3, Comm: "child2"},
+			{PID: 2, Comm: "child1", TaskState: "Alive"},
+			{PID: 3, Comm: "child2", TaskState: "Alive"},
 		},
 	}
 
@@ -141,21 +146,25 @@ func TestBuildJSONPsTree(t *testing.T) {
 }
 
 func TestBuildJSONPsNode(t *testing.T) {
+	aliveState := uint32(1) // COMPEL_TASK_ALIVE
+	coreEntry := &criu_core.CoreEntry{Tc: &criu_core.TaskCoreEntry{TaskState: &aliveState}}
 	psTree := &crit.PsTree{
 		PID:  1,
 		Comm: "root",
+		Core: coreEntry,
 		Children: []*crit.PsTree{
-			{PID: 2, Comm: "child1"},
-			{PID: 3, Comm: "child2"},
+			{PID: 2, Comm: "child1", Core: coreEntry},
+			{PID: 3, Comm: "child2", Core: coreEntry},
 		},
 	}
 
 	expectedPsNode := PsNode{
-		PID:  1,
-		Comm: "root",
+		PID:       1,
+		Comm:      "root",
+		TaskState: "Alive",
 		Children: []PsNode{
-			{PID: 2, Comm: "child1"},
-			{PID: 3, Comm: "child2"},
+			{PID: 2, Comm: "child1", TaskState: "Alive"},
+			{PID: 3, Comm: "child2", TaskState: "Alive"},
 		},
 	}
 

--- a/internal/tree.go
+++ b/internal/tree.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -191,6 +192,11 @@ func addPsTreeToTree(
 		if !taskState.IsAliveOrStopped() {
 			return nil
 		}
+
+		// Sort children by PID for consistent output
+		sort.Slice(root.Children, func(i, j int) bool {
+			return root.Children[i].PID < root.Children[j].PID
+		})
 
 		// attach environment variables to process
 		if PsTreeEnv {

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ test-junit: test-imgs
 	bats -F junit checkpointctl.bats > junit.xml
 
 test-imgs: piggie/piggie
-	$(eval PID := $(shell export TEST_ENV=BAR TEST_ENV_EMPTY=; piggie/piggie --tcp-socket))
+	$(eval PID := $(shell export TEST_ENV=BAR TEST_ENV_EMPTY=; piggie/piggie --tcp-socket --zombie))
 	mkdir -p $@
 	$(CRIU) dump --tcp-established -v4 -o dump.log -D $@ -t $(PID) || cat $@/dump.log
 

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -386,9 +386,15 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl inspect "$TEST_TMP_DIR2"/test.tar --files
 	[ "$status" -eq 0 ]
+
 	[[ ${lines[11]} == *"[REG 0]"* ]]
 	[[ ${lines[25]} == *"[cwd]"* ]]
 	[[ ${lines[26]} == *"[root]"* ]]
+
+	[[ ${lines[27]} == *"[5 (Dead)]  piggie-zombie"* ]]
+	[[ ${lines[28]} == *"[6 (Stopped)]  stopped-child"* ]]
+	[[ ${lines[29]} == *"Open files"* ]]
+	[[ ${lines[33]} == *"[7]  alive-child"* ]]
 }
 
 @test "Run checkpointctl inspect with tar file and --files and missing files.img" {

--- a/test/checkpointctl.bats
+++ b/test/checkpointctl.bats
@@ -681,7 +681,7 @@ function teardown() {
 	( cd "$TEST_TMP_DIR1" && tar cf "$TEST_TMP_DIR2"/test.tar . )
 	checkpointctl memparse --search=PATH --context=10 "$TEST_TMP_DIR2"/test.tar --pid=1
 	[ "$status" -eq 0 ]
-	[[ ${lines[3]} == *"PATH"* ]]
+	[[ "$(printf '%s\n' "${lines[@]}")" == *"PATH"* ]]
 }
 
 @test "Run checkpointctl memparse with --search-regex='HOME=([^?]+)' " {

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -90,7 +90,8 @@ void run_tcp_client(void)
 	int client_socket, max_connection_tries = 5;
 	struct sockaddr_in server_address;
 	char buffer[MAX_BUFFER_SIZE];
-	bool connected = false, ret;
+	bool connected = false;
+	pid_t ret;
 
 	ret = fork();
 	if (ret < 0) {

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -79,7 +79,9 @@ void run_tcp_server(void)
 
 	while (1) {
 		memset(buffer, 0, sizeof(buffer));
-		recv(client_socket, buffer, sizeof(buffer), 0);
+		ssize_t n = recv(client_socket, buffer, sizeof(buffer), 0);
+		if (n <= 0)
+			break;
 	}
 
 	close(server_socket);

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
 	}
 
 	stk = mmap(NULL, STKS, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_GROWSDOWN, 0, 0);
-	pid = clone(do_test, stk + STKS, SIGCHLD | CLONE_NEWPID, (void*)&opts);
+	pid = clone(do_test, (char *)stk + STKS, SIGCHLD | CLONE_NEWPID, (void*)&opts);
 	if (pid < 0) {
 		fprintf(stderr, "clone() failed: %m\n");
 		return 1;

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -220,7 +220,7 @@ int main(int argc, char **argv) {
 	void *stk;
 	int i, pid, log_fd, option;
 	bool usage_error = false;
-	opts_t opts = {NULL};
+	opts_t opts = {0};
 	int ret;
 
 	ret = parse_options(argc, argv, &usage_error, &opts);

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -170,10 +170,17 @@ static int do_test(void *opts_ptr)
 
 	if (opts->log_file) {
 		fd = open(opts->log_file, O_WRONLY | O_TRUNC | O_CREAT, 0600);
-		dup2(fd, 1);
-		dup2(fd, 2);
-		if (fd != 1 && fd != 2)
+		if (fd < 0) {
+			perror("open");
+			return -1;
+		}
+
+		dup2(fd, STDOUT_FILENO);
+		dup2(fd, STDERR_FILENO);
+
+		if (fd != STDOUT_FILENO && fd != STDERR_FILENO) {
 			close(fd);
+		}
 	}
 
 	if (opts->use_tcp_socket) {

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include <sys/prctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 
 #define STKS	(4*4096)
 

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -94,6 +94,7 @@ void run_tcp_client(void)
 	int client_socket, max_connection_tries = 5;
 	struct sockaddr_in server_address = {0};
 	char buffer[MAX_BUFFER_SIZE];
+	const char msg[] = "ping";
 	bool connected = false;
 	pid_t ret;
 
@@ -137,7 +138,11 @@ void run_tcp_client(void)
 	}
 
 	while (1) {
-		send(client_socket, "ping", 5, 0);
+		ssize_t sent = send(client_socket, msg, sizeof(msg) - 1, 0);
+		if (sent == -1) {
+			perror("send");
+		}
+
 		/* Send messages every second */
 		sleep(1);
 	}

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -31,7 +31,7 @@ typedef struct {
 void run_tcp_server(void)
 {
 	int server_socket, client_socket, ret;
-	struct sockaddr_in server_address, client_address;
+	struct sockaddr_in server_address = {0}, client_address = {0};
 	char buffer[MAX_BUFFER_SIZE];
 	const int enable = 1;
 
@@ -90,7 +90,7 @@ void run_tcp_server(void)
 void run_tcp_client(void)
 {
 	int client_socket, max_connection_tries = 5;
-	struct sockaddr_in server_address;
+	struct sockaddr_in server_address = {0};
 	char buffer[MAX_BUFFER_SIZE];
 	bool connected = false;
 	pid_t ret;

--- a/test/piggie/piggie.c
+++ b/test/piggie/piggie.c
@@ -53,8 +53,8 @@ void run_tcp_server(void)
 		exit(EXIT_FAILURE);
 	}
 
-	setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, &(int){1}, sizeof(int));
-	setsockopt(server_socket, SOL_SOCKET, SO_REUSEPORT, &(int){1}, sizeof(int));
+	setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+	setsockopt(server_socket, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable));
 
 	server_address.sin_family = AF_INET;
 	server_address.sin_addr.s_addr = INADDR_ANY;


### PR DESCRIPTION
When parsing the state of a checkpoint, we need to take into account the state of the PID we are analysing. This can be alive, stopped, dead, or zombie. In particular, only processes in alive and stopped task state have CRIU images for memory pages, open files, sockets, etc. This patch extends checkpointctl to display the TaskState of non-alive processes, and skip parsing the runtime state of dead or zombie tasks.

Example:
```
$ checkpointctl inspect --ps-tree-env /tmp/test.tar 

Displaying container checkpoint tree view from /tmp/test.tar

recursing_meninsky
├── Image: docker.io/library/python:3-alpine
├── ID: fa8e42820889e31fbd668b9c223542b815ee8436df59a92734079cb4bf1eadd4
├── Runtime: runc
├── Created: 2026-01-11T13:50:07Z
├── Engine: Podman
├── Checkpoint size: 3.5 MiB
│   └── Memory pages size: 3.5 MiB
├── Root FS diff size: 34.0 KiB
└── Process tree
    └── [1]  python3
        ├── Environment variables
        │   ├── PYTHON_VERSION=3.14.2
        │   ├── PYTHON_SHA256=ce543ab854bc256b61b71e9b27f831ffd1bfd60a479d639f8be7f9757cf573e9
        │   ├── PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
        │   ├── container=podman
        │   ├── HOME=/root
        │   └── HOSTNAME=fa8e42820889
        └── [6 (Dead)]  python3
```

```
$ checkpointctl inspect --sockets /tmp/test.tar 

Displaying container checkpoint tree view from /tmp/test.tar

recursing_meninsky
├── Image: docker.io/library/python:3-alpine
├── ID: fa8e42820889e31fbd668b9c223542b815ee8436df59a92734079cb4bf1eadd4
├── Runtime: runc
├── Created: 2026-01-11T13:50:07Z
├── Engine: Podman
├── Checkpoint size: 3.5 MiB
│   └── Memory pages size: 3.5 MiB
├── Root FS diff size: 34.0 KiB
└── Process tree
    └── [1]  python3
        └── [6 (Dead)]  python3
```

This patch uses changes to go-criu from https://github.com/checkpoint-restore/go-criu/pull/220