### PR TITLE
lib: Add CheckpointedPodOptions structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ test-junit: $(NAME)
 .PHONY: coverage
 coverage: $(NAME).coverage
 	mkdir -p $(COVERAGE_PATH)
+	$(GO) test -cover ./... -args -test.gocoverdir=$(COVERAGE_PATH)
 	COVERAGE_PATH=$(COVERAGE_PATH) COVERAGE=1 make -C test
 	# Print coverage from this run
 	$(GO) tool covdata percent -i=${COVERAGE_PATH}

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -79,6 +79,14 @@ type KubernetesContainerCheckpointMetadata struct {
 	Checkpoints   []KubernetesCheckpoint `json:"checkpoints"`
 }
 
+// CheckpointedPodOptions contains metadata about a checkpointed pod
+type CheckpointedPodOptions struct {
+	// Version is the version of the pod checkpoint format
+	Version int `json:"version"`
+	// Containers is a map with the short container name as key and the full name as value
+	Containers map[string]string `json:"containers"`
+}
+
 func ReadContainerCheckpointSpecDump(checkpointDirectory string) (*spec.Spec, string, error) {
 	var specDump spec.Spec
 	specDumpFile, err := ReadJSONFile(&specDump, checkpointDirectory, SpecDumpFile)
@@ -105,6 +113,13 @@ func ReadContainerCheckpointStatusFile(checkpointDirectory string) (*ContainerdS
 	statusFile, err := ReadJSONFile(&containerdStatus, checkpointDirectory, StatusFile)
 
 	return &containerdStatus, statusFile, err
+}
+
+func ReadContainerCheckpointPodOptions(checkpointDirectory string) (*CheckpointedPodOptions, string, error) {
+	var podOptions CheckpointedPodOptions
+	podOptionsFile, err := ReadJSONFile(&podOptions, checkpointDirectory, PodOptionsFile)
+
+	return &podOptions, podOptionsFile, err
 }
 
 // WriteJSONFile marshalls and writes the given data to a JSON file

--- a/lib/metadata_test.go
+++ b/lib/metadata_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import (
+	"testing"
+)
+
+func TestReadContainerCheckpointPodOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		podOptions  CheckpointedPodOptions
+		wantVersion int
+		wantContLen int
+	}{
+		{
+			name: "valid pod options",
+			podOptions: CheckpointedPodOptions{
+				Version: 1,
+				Containers: map[string]string{
+					"short-name": "full-container-name",
+					"another":    "another-full-name",
+				},
+			},
+			wantVersion: 1,
+			wantContLen: 2,
+		},
+		{
+			name: "empty containers",
+			podOptions: CheckpointedPodOptions{
+				Version:    2,
+				Containers: map[string]string{},
+			},
+			wantVersion: 2,
+			wantContLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			if _, err := WriteJSONFile(&tt.podOptions, tmpDir, PodOptionsFile); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+
+			podOptions, _, err := ReadContainerCheckpointPodOptions(tmpDir)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if podOptions.Version != tt.wantVersion {
+				t.Errorf("expected version %d, got %d", tt.wantVersion, podOptions.Version)
+			}
+
+			if len(podOptions.Containers) != tt.wantContLen {
+				t.Errorf("expected %d containers, got %d", tt.wantContLen, len(podOptions.Containers))
+			}
+		})
+	}
+}
+
+func TestReadContainerCheckpointPodOptionsFileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, _, err := ReadContainerCheckpointPodOptions(tmpDir)
+	if err == nil {
+		t.Errorf("expected error for non-existent file, got nil")
+	}
+}


### PR DESCRIPTION
Add a new structure to store metadata about checkpointed pods. This structure contains the checkpoint format version and a map of containers with the short container name as key and the full name as value.

This metadata is used by pod-level checkpoint to track which containers are included in the checkpoint archive.

This change is in preparation for KEP-5823: Pod-Level Checkpoint/Restore.

Generated with Claude Code (https://claude.ai/code)