### PR TITLE
make: allow build variables to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-SHELL = /bin/bash
+SHELL ?= /bin/bash
 PREFIX ?= $(DESTDIR)/usr/local
 BINDIR ?= $(PREFIX)/bin
 GO ?= go
-GOPATH := $(shell $(GO) env GOPATH)
-GOBIN := $(shell $(GO) env GOBIN)
+GOPATH ?= $(shell $(GO) env GOPATH)
+GOBIN ?= $(shell $(GO) env GOBIN)
 GO_SRC = $(shell find . -name \*.go)
-GO_BUILD = $(GO) build
+GO_BUILD ?= $(GO) build
 NAME = checkpointctl
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions


### PR DESCRIPTION
Use `?=` instead of `:=` when assigning GOPATH and GOBIN so that environment or command-line values take precedence over the defaults.

Example:

    $ sudo make install PREFIX=/usr
    /bin/bash: line 1: go: command not found
    /bin/bash: line 1: go: command not found
      INSTALL  checkpointctl
    make[1]: Entering directory '/home/radostin/Projects/checkpointctl/docs'
      INSTALL  checkpointctl-inspect.1 checkpointctl-memparse.1 checkpointctl-show.1 checkpointctl.1
    make[1]: Leaving directory '/home/radostin/Projects/checkpointctl/docs'

This error occurs because sudo runs a non-interactive shell that does not source the user's .bashrc, where Go is commonly added to `PATH` (e.g. `/usr/local/go/bin`).

Switch the assignments to `?=` so they are only evaluated when the variables are not already defined. For consistency, also allow overriding `SHELL` and `GO_BUILD`.