### PR TITLE
Add weekly CI container build for pre-installed test dependencies

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,95 @@
+name: Build and Publish CI Container
+
+on:
+  schedule:
+    # Run every Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        arch: [ x86_64, aarch64 ]
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-24.04
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+    outputs:
+      digest-x86_64: ${{ steps.export.outputs.digest-x86_64 }}
+      digest-aarch64: ${{ steps.export.outputs.digest-aarch64 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/ci
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./test/ci/Containerfile
+          platforms: linux/${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository }}/ci,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        id: export
+        run: |
+          echo "digest-${{ matrix.arch }}=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
+
+  publish:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ github.repository }}/ci:latest \
+            ${{ env.REGISTRY }}/${{ github.repository }}/ci@${{ needs.build.outputs.digest-x86_64 }} \
+            ${{ env.REGISTRY }}/${{ github.repository }}/ci@${{ needs.build.outputs.digest-aarch64 }}
+
+      - name: Output image details
+        run: |
+          echo "Container built and pushed successfully!"
+          echo "Image: ${{ env.REGISTRY }}/${{ github.repository }}/ci:latest"

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -1,0 +1,37 @@
+name: Cleanup Untagged Packages
+
+on:
+  schedule:
+    # Run every Sunday at 02:00 UTC
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Delete untagged CI container images
+        id: cleanup-ci
+        continue-on-error: true
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: checkpointctl/ci
+          package-type: container
+          min-versions-to-keep: 3
+          delete-only-untagged-versions: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report cleanup results
+        run: |
+          echo "Cleanup Results:"
+          echo "CI container cleanup: ${{ steps.cleanup-ci.outcome }}"
+
+          if [[ "${{ steps.cleanup-ci.outcome }}" == "failure" ]]; then
+            echo "Warning: CI container cleanup failed"
+            echo "Package may not exist yet"
+          fi
+
+          echo "Cleanup workflow completed"

--- a/test/ci/Containerfile
+++ b/test/ci/Containerfile
@@ -1,0 +1,19 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN dnf install -y \
+	bash \
+	bash-completion \
+	bats \
+	criu \
+	fish \
+	git \
+	golang \
+	iptables \
+	iproute \
+	jq \
+	kmod \
+	make \
+	rubygem-asciidoctor \
+	ShellCheck \
+	zsh \
+	&& dnf clean all


### PR DESCRIPTION
  Currently the coverage.yml and tests.yml workflows use `fedora:latest` as their container image and install all required packages (golang, bats, criu, ShellCheck, etc.) from scratch on every single CI run. This means                                                                                                                                                                     
  every push and every pull request spends time running dnf install before any actual test work begins, adding unnecessary latency and putting load on Fedora mirrors.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                              
  This PR introduces a pre-built CI container image that has all required ackages already installed. The image is built once a week and pushed to the GitHub Container Registry (ghcr.io), so that the test and coverage workflows can pull it directly and skip the package installation step entirely.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                              
  The changes are split into two commits intentionally. This first commit adds the container infrastructure — the Containerfile and the build and cleanup workflows — so that the container image is created and available                                                                                                                                                                    
  in the registry before the test workflows are updated to reference it. The second commit, which switches coverage.yml and tests.yml to use the pre-built image, will be submitted separately once the image exists.              