### PR TITLE
checkpointctl: fix lint issue

### DIFF
--- a/checkpointctl.go
+++ b/checkpointctl.go
@@ -43,7 +43,6 @@ func main() {
 		rootCommand.AddCommand(cmd.CreatePluginCommand(plugin))
 	}
 
-
 	rootCommand.Version = version
 
 	if err := rootCommand.Execute(); err != nil {


### PR DESCRIPTION
An extra new line was introduced by commit 4c56c274.

```
$ golangci-lint run
checkpointctl.go:46:1: File is not properly formatted (gofumpt)

^
1 issues:
* gofumpt: 1 make: *** [Makefile:56: golang-lint] Error 1
```