### PR TITLE
ci: use pre-built CI container in coverage and test workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,17 +4,18 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: ghcr.io/${{ github.repository }}/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --privileged
     steps:
-      - name: Install tools
-        run: |
-          dnf install -y bats iptables iproute jq criu golang make git
       - name: Fix git safe directory
         run: git config --global --add safe.directory /__w/checkpointctl/checkpointctl
       - name: checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,18 +4,23 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: ghcr.io/${{ github.repository }}/ci:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --privileged -v /lib/modules:/lib/modules
     steps:
+      - name: Fix git safe directory
+        run: git config --global --add safe.directory /__w/checkpointctl/checkpointctl
       - uses: actions/checkout@v4
-      - name: Install tools
+      - name: Load kernel modules
         run: |
-          dnf install -y golang make ShellCheck bats criu rubygem-asciidoctor iptables iproute kmod jq bash bash-completion zsh fish
           modprobe -va ip_tables ip6table_filter nf_conntrack nf_conntrack_netlink
       - name: Run make shellcheck
         run: make shellcheck


### PR DESCRIPTION
Replace fedora:latest with the weekly built CI container image from ghcr.io and remove the dnf install steps, as all packages are already included in the container.