### PR TITLE
ci: add git safe.directory to CI container image

### DIFF
--- a/test/ci/Containerfile
+++ b/test/ci/Containerfile
@@ -17,3 +17,5 @@ RUN dnf install -y \
 	ShellCheck \
 	zsh \
 	&& dnf clean all
+
+RUN git config --global --add safe.directory /__w/checkpointctl/checkpointctl


### PR DESCRIPTION
Move the git safe.directory configuration into the Containerfile so it is baked into the CI container image instead of being repeated in every workflow.

First PR of two to move this line to the container creation time. Not yet removed from the yaml files as that would break CI.