### PR TITLE
fix: memparse sub-command nil pointer

### DIFF
--- a/cmd/memparse.go
+++ b/cmd/memparse.go
@@ -145,7 +145,7 @@ func showProcessMemorySizeTables(tasks []internal.Task) error {
 		var memSize int64
 
 		for _, entry := range pagemapEntries {
-			memSize += int64(*entry.NrPages) * int64(pageSize)
+			memSize += int64(entry.GetNrPages()) * int64(pageSize)
 		}
 
 		shmemSize, err := memReader.GetShmemSize()


### PR DESCRIPTION
Running `memparse` on checkpoints generated by older CRIU versions could cause a nil pointer dereference:

```bash
./checkpointctl memparse checkpoint-nginx-65cb664d74-lcx7s_tcloud-app-nginx-2026-07-31T13:54:09+08:00.tar

Older CRIU checkpoint images store the page count in the required compat_nr_pages field. In these images, the newer optional nr_pages field is absent.

memparse directly dereferenced entry.NrPages, causing a panic when the field was nil:

panic: runtime error: invalid memory address or nil pointer dereference

Additionally, callers using GetNrPages() received 0 for older checkpoint images, resulting in incorrect memory-size calculations.

- Use entry.GetNrPages() instead of directly dereferencing entry.NrPages.
- Make GetNrPages() fall back to compat_nr_pages when nr_pages is not present.

This preserves support for newer CRIU checkpoints while restoring compatibility with older checkpoint formats.

go test ./...
./checkpointctl memparse checkpoint-nginx-65cb664d74-lcx7s_tcloud-app-nginx-2026-07-31T13:54:09+08:00.tar

The command now completes successfully and displays process memory sizes.